### PR TITLE
Fix CI: add Spring Boot main class for bootJar

### DIFF
--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/StablebridgeIndexerApplication.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/StablebridgeIndexerApplication.java
@@ -1,0 +1,12 @@
+package com.stablebridge.indexer;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class StablebridgeIndexerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(StablebridgeIndexerApplication.class, args);
+    }
+}


### PR DESCRIPTION
## Summary
- Added `StablebridgeIndexerApplication.java` — the Spring Boot entry point required by the `bootJar` Gradle task
- The scaffold had empty package directories but no Java source files, causing `bootJar` to fail with "Main class name has not been configured and it could not be resolved from classpath"

## Test plan
- [x] Verified `./gradlew build -x test -x integrationTest -x spotlessCheck` passes locally
- [ ] CI Build job should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)