### PR TITLE
SBI-16: Add Feign IndexerClient with auto-configuration

### DIFF
--- a/stablebridge-indexer-client/src/main/java/com/stablebridge/indexer/client/ApiKeyRequestInterceptor.java
+++ b/stablebridge-indexer-client/src/main/java/com/stablebridge/indexer/client/ApiKeyRequestInterceptor.java
@@ -1,0 +1,18 @@
+package com.stablebridge.indexer.client;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ApiKeyRequestInterceptor implements RequestInterceptor {
+
+    private static final String API_KEY_HEADER = "X-API-Key";
+
+    private final String apiKey;
+
+    @Override
+    public void apply(RequestTemplate template) {
+        template.header(API_KEY_HEADER, apiKey);
+    }
+}

--- a/stablebridge-indexer-client/src/main/java/com/stablebridge/indexer/client/IndexerClient.java
+++ b/stablebridge-indexer-client/src/main/java/com/stablebridge/indexer/client/IndexerClient.java
@@ -1,0 +1,35 @@
+package com.stablebridge.indexer.client;
+
+import com.stablebridge.indexer.api.IndexerStatusResponse;
+import com.stablebridge.indexer.api.NetworkType;
+import com.stablebridge.indexer.api.WalletAddressRequest;
+import com.stablebridge.indexer.api.WalletAddressResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@FeignClient(name = "indexer-client", url = "${indexer.client.url}")
+public interface IndexerClient {
+
+    @PostMapping("/api/v1/wallets")
+    WalletAddressResponse registerWallet(@RequestBody WalletAddressRequest request);
+
+    @GetMapping("/api/v1/wallets/{address}")
+    WalletAddressResponse getWallet(
+            @PathVariable String address, @RequestParam NetworkType networkType);
+
+    @DeleteMapping("/api/v1/wallets/{address}")
+    void deleteWallet(@PathVariable String address, @RequestParam NetworkType networkType);
+
+    @GetMapping("/api/v1/wallets")
+    List<WalletAddressResponse> listWallets(@RequestParam NetworkType networkType);
+
+    @GetMapping("/api/v1/status")
+    List<IndexerStatusResponse> getStatus();
+}

--- a/stablebridge-indexer-client/src/main/java/com/stablebridge/indexer/client/IndexerClientAutoConfiguration.java
+++ b/stablebridge-indexer-client/src/main/java/com/stablebridge/indexer/client/IndexerClientAutoConfiguration.java
@@ -1,0 +1,20 @@
+package com.stablebridge.indexer.client;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+@ConditionalOnProperty(name = "indexer.client.url")
+@EnableConfigurationProperties(IndexerClientProperties.class)
+@EnableFeignClients(clients = IndexerClient.class)
+public class IndexerClientAutoConfiguration {
+
+    @Bean
+    public ApiKeyRequestInterceptor apiKeyRequestInterceptor(
+            IndexerClientProperties properties) {
+        return new ApiKeyRequestInterceptor(properties.apiKey());
+    }
+}

--- a/stablebridge-indexer-client/src/main/java/com/stablebridge/indexer/client/IndexerClientProperties.java
+++ b/stablebridge-indexer-client/src/main/java/com/stablebridge/indexer/client/IndexerClientProperties.java
@@ -1,0 +1,6 @@
+package com.stablebridge.indexer.client;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "indexer.client")
+public record IndexerClientProperties(String url, String apiKey) {}

--- a/stablebridge-indexer-client/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/stablebridge-indexer-client/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.stablebridge.indexer.client.IndexerClientAutoConfiguration

--- a/stablebridge-indexer-client/src/test/java/com/stablebridge/indexer/client/ApiKeyRequestInterceptorTest.java
+++ b/stablebridge-indexer-client/src/test/java/com/stablebridge/indexer/client/ApiKeyRequestInterceptorTest.java
@@ -1,0 +1,33 @@
+package com.stablebridge.indexer.client;
+
+import feign.RequestTemplate;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApiKeyRequestInterceptorTest {
+
+    private static final String API_KEY = "test-api-key-12345";
+
+    private final ApiKeyRequestInterceptor interceptor = new ApiKeyRequestInterceptor(API_KEY);
+
+    @Test
+    void shouldAddApiKeyHeader() {
+        RequestTemplate template = new RequestTemplate();
+
+        interceptor.apply(template);
+
+        assertThat(template.headers().get("X-API-Key")).containsExactly(API_KEY);
+    }
+
+    @Test
+    void shouldNotOverwriteExistingHeaders() {
+        RequestTemplate template = new RequestTemplate();
+        template.header("Content-Type", "application/json");
+
+        interceptor.apply(template);
+
+        assertThat(template.headers().get("X-API-Key")).containsExactly(API_KEY);
+        assertThat(template.headers().get("Content-Type")).containsExactly("application/json");
+    }
+}


### PR DESCRIPTION
## Summary
- **IndexerClient**: Feign interface with wallet CRUD and indexer status endpoints (`/api/v1/wallets`, `/api/v1/status`)
- **ApiKeyRequestInterceptor**: Injects `X-API-Key` header on all outgoing requests from configured property
- **IndexerClientAutoConfiguration**: Spring Boot auto-configuration with `@ConditionalOnProperty(name = "indexer.client.url")` guard, registered via `META-INF/spring/AutoConfiguration.imports`
- **IndexerClientProperties**: `@ConfigurationProperties` record for `indexer.client.url` and `indexer.client.api-key`

## Design
- Client module depends only on `stablebridge-indexer-api` (shared DTOs), not the main app module
- Consumers add this module as a dependency and configure `indexer.client.url` / `indexer.client.api-key` to get a ready-to-use Feign client
- Auto-configuration only activates when `indexer.client.url` is set

## Test plan
- [x] `ApiKeyRequestInterceptorTest` — verifies `X-API-Key` header is added to `RequestTemplate`
- [x] `ApiKeyRequestInterceptorTest` — verifies existing headers are not overwritten
- [x] `./gradlew build` passes (all modules, spotless, unit + integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)