### PR TITLE
SBI-12: Add Kafka transfer event publisher

### DIFF
--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/messaging/KafkaTransferEventPublisher.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/messaging/KafkaTransferEventPublisher.java
@@ -1,0 +1,51 @@
+package com.stablebridge.indexer.infrastructure.messaging;
+
+import com.stablebridge.indexer.api.TransferEvent;
+import com.stablebridge.indexer.domain.event.TransferDetectedEvent;
+import com.stablebridge.indexer.domain.port.TransferEventPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Kafka-based implementation of {@link TransferEventPublisher}.
+ *
+ * <p>Publishes confirmed transfer events to per-chain Kafka topics
+ * ({@code transfer.events.<chainId>}) with {@code toAddress} as the partition key,
+ * ensuring per-wallet ordering for downstream consumers.
+ *
+ * <p>At-least-once delivery: Kafka publish must always happen <em>before</em>
+ * saving block progress to Redis. Consumer dedup key: {@code txHash + toAddress + networkId}.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+class KafkaTransferEventPublisher implements TransferEventPublisher {
+
+    private static final String TOPIC_PREFIX = "transfer.events.";
+
+    private final KafkaTemplate<String, TransferEvent> kafkaTemplate;
+    private final TransferEventMapper transferEventMapper;
+
+    @Override
+    public void publish(TransferDetectedEvent event) {
+        TransferEvent transferEvent = transferEventMapper.toTransferEvent(event);
+        String topic = TOPIC_PREFIX + event.transfer().chainId().name();
+        String key = event.transfer().toAddress();
+
+        log.info("Publishing transfer event to topic={}, key={}, txHash={}",
+                topic, key, transferEvent.txHash());
+
+        kafkaTemplate.send(topic, key, transferEvent);
+    }
+
+    @Override
+    public void publishAll(List<TransferDetectedEvent> events) {
+        for (TransferDetectedEvent event : events) {
+            publish(event);
+        }
+    }
+}

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/messaging/TransferEventMapper.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/messaging/TransferEventMapper.java
@@ -1,0 +1,29 @@
+package com.stablebridge.indexer.infrastructure.messaging;
+
+import com.stablebridge.indexer.api.TransferEvent;
+import com.stablebridge.indexer.domain.event.TransferDetectedEvent;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+interface TransferEventMapper {
+
+    @Mapping(source = "transfer.txHash", target = "txHash")
+    @Mapping(source = "transfer.fromAddress", target = "fromAddress")
+    @Mapping(source = "transfer.toAddress", target = "toAddress")
+    @Mapping(source = "transfer.rawAmount", target = "rawAmount")
+    @Mapping(source = "transfer.amount", target = "amount")
+    @Mapping(source = "transfer.decimals", target = "decimals")
+    @Mapping(source = "transfer.tokenSymbol", target = "tokenSymbol")
+    @Mapping(source = "transfer.tokenContractAddress", target = "tokenContractAddress")
+    @Mapping(source = "transfer.blockNumber", target = "blockNumber")
+    @Mapping(source = "transfer.blockHash", target = "blockHash")
+    @Mapping(source = "transfer.transactionIndex", target = "transactionIndex")
+    @Mapping(source = "transfer.logIndex", target = "logIndex")
+    @Mapping(target = "chainId", expression = "java(event.transfer().chainId().name())")
+    @Mapping(target = "networkType", expression = "java(event.transfer().chainId().networkType().name())")
+    @Mapping(source = "transfer.timestamp", target = "timestamp")
+    @Mapping(source = "transfer.nativeTransfer", target = "nativeTransfer")
+    @Mapping(source = "detectedAt", target = "detectedAt")
+    TransferEvent toTransferEvent(TransferDetectedEvent event);
+}

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/messaging/KafkaTransferEventPublisherTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/messaging/KafkaTransferEventPublisherTest.java
@@ -1,0 +1,194 @@
+package com.stablebridge.indexer.infrastructure.messaging;
+
+import com.stablebridge.indexer.api.TransferEvent;
+import com.stablebridge.indexer.domain.event.TransferDetectedEvent;
+import com.stablebridge.indexer.domain.model.ChainId;
+import com.stablebridge.indexer.domain.model.Transfer;
+import com.stablebridge.indexer.testutil.TransferFixtures;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaTransferEventPublisherTest {
+
+    @Mock
+    private KafkaTemplate<String, TransferEvent> kafkaTemplate;
+
+    @Mock
+    private TransferEventMapper transferEventMapper;
+
+    @InjectMocks
+    private KafkaTransferEventPublisher publisher;
+
+    @Test
+    void publish_sendsToCorrectTopicWithToAddressKey() {
+        // given
+        TransferDetectedEvent event = TransferFixtures.aTransferDetectedEvent().build();
+        Transfer transfer = event.transfer();
+
+        TransferEvent expectedApiEvent = new TransferEvent(
+                transfer.txHash(),
+                transfer.fromAddress(),
+                transfer.toAddress(),
+                transfer.rawAmount(),
+                transfer.amount(),
+                transfer.decimals(),
+                transfer.tokenSymbol(),
+                transfer.tokenContractAddress(),
+                transfer.blockNumber(),
+                transfer.blockHash(),
+                transfer.transactionIndex(),
+                transfer.logIndex(),
+                transfer.chainId().name(),
+                transfer.chainId().networkType().name(),
+                transfer.timestamp(),
+                transfer.nativeTransfer(),
+                event.detectedAt());
+
+        given(transferEventMapper.toTransferEvent(event)).willReturn(expectedApiEvent);
+
+        // when
+        publisher.publish(event);
+
+        // then
+        then(kafkaTemplate).should().send(
+                "transfer.events.ETHEREUM",
+                TransferFixtures.DEFAULT_TO_ADDRESS,
+                expectedApiEvent);
+    }
+
+    @Test
+    void publish_usesChainIdForTopicName() {
+        // given
+        Transfer polygonTransfer = TransferFixtures.aTransfer()
+                .chainId(ChainId.POLYGON)
+                .build();
+        TransferDetectedEvent event = TransferDetectedEvent.builder()
+                .transfer(polygonTransfer)
+                .detectedAt(Instant.parse("2026-03-19T10:15:31Z"))
+                .build();
+
+        TransferEvent expectedApiEvent = new TransferEvent(
+                polygonTransfer.txHash(),
+                polygonTransfer.fromAddress(),
+                polygonTransfer.toAddress(),
+                polygonTransfer.rawAmount(),
+                polygonTransfer.amount(),
+                polygonTransfer.decimals(),
+                polygonTransfer.tokenSymbol(),
+                polygonTransfer.tokenContractAddress(),
+                polygonTransfer.blockNumber(),
+                polygonTransfer.blockHash(),
+                polygonTransfer.transactionIndex(),
+                polygonTransfer.logIndex(),
+                "POLYGON",
+                "EVM",
+                polygonTransfer.timestamp(),
+                polygonTransfer.nativeTransfer(),
+                event.detectedAt());
+
+        given(transferEventMapper.toTransferEvent(event)).willReturn(expectedApiEvent);
+
+        // when
+        publisher.publish(event);
+
+        // then
+        then(kafkaTemplate).should().send(
+                "transfer.events.POLYGON",
+                TransferFixtures.DEFAULT_TO_ADDRESS,
+                expectedApiEvent);
+    }
+
+    @Test
+    void publishAll_sendsEachEventIndividually() {
+        // given
+        Transfer firstTransfer = TransferFixtures.aTransfer()
+                .toAddress("0xfirst1234567890abcdef1234567890abcdef1234")
+                .build();
+        Transfer secondTransfer = TransferFixtures.aTransfer()
+                .toAddress("0xsecond234567890abcdef1234567890abcdef1234")
+                .build();
+
+        TransferDetectedEvent firstEvent = TransferDetectedEvent.builder()
+                .transfer(firstTransfer)
+                .detectedAt(Instant.parse("2026-03-19T10:15:31Z"))
+                .build();
+        TransferDetectedEvent secondEvent = TransferDetectedEvent.builder()
+                .transfer(secondTransfer)
+                .detectedAt(Instant.parse("2026-03-19T10:15:32Z"))
+                .build();
+
+        TransferEvent firstApiEvent = new TransferEvent(
+                firstTransfer.txHash(),
+                firstTransfer.fromAddress(),
+                firstTransfer.toAddress(),
+                firstTransfer.rawAmount(),
+                firstTransfer.amount(),
+                firstTransfer.decimals(),
+                firstTransfer.tokenSymbol(),
+                firstTransfer.tokenContractAddress(),
+                firstTransfer.blockNumber(),
+                firstTransfer.blockHash(),
+                firstTransfer.transactionIndex(),
+                firstTransfer.logIndex(),
+                firstTransfer.chainId().name(),
+                firstTransfer.chainId().networkType().name(),
+                firstTransfer.timestamp(),
+                firstTransfer.nativeTransfer(),
+                firstEvent.detectedAt());
+
+        TransferEvent secondApiEvent = new TransferEvent(
+                secondTransfer.txHash(),
+                secondTransfer.fromAddress(),
+                secondTransfer.toAddress(),
+                secondTransfer.rawAmount(),
+                secondTransfer.amount(),
+                secondTransfer.decimals(),
+                secondTransfer.tokenSymbol(),
+                secondTransfer.tokenContractAddress(),
+                secondTransfer.blockNumber(),
+                secondTransfer.blockHash(),
+                secondTransfer.transactionIndex(),
+                secondTransfer.logIndex(),
+                secondTransfer.chainId().name(),
+                secondTransfer.chainId().networkType().name(),
+                secondTransfer.timestamp(),
+                secondTransfer.nativeTransfer(),
+                secondEvent.detectedAt());
+
+        given(transferEventMapper.toTransferEvent(firstEvent)).willReturn(firstApiEvent);
+        given(transferEventMapper.toTransferEvent(secondEvent)).willReturn(secondApiEvent);
+
+        // when
+        publisher.publishAll(List.of(firstEvent, secondEvent));
+
+        // then
+        then(kafkaTemplate).should().send(
+                "transfer.events.ETHEREUM",
+                "0xfirst1234567890abcdef1234567890abcdef1234",
+                firstApiEvent);
+        then(kafkaTemplate).should().send(
+                "transfer.events.ETHEREUM",
+                "0xsecond234567890abcdef1234567890abcdef1234",
+                secondApiEvent);
+    }
+
+    @Test
+    void publishAll_withEmptyList_doesNotSend() {
+        // when
+        publisher.publishAll(List.of());
+
+        // then
+        then(kafkaTemplate).shouldHaveNoInteractions();
+    }
+}

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/messaging/TransferEventMapperTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/messaging/TransferEventMapperTest.java
@@ -1,0 +1,52 @@
+package com.stablebridge.indexer.infrastructure.messaging;
+
+import com.stablebridge.indexer.api.TransferEvent;
+import com.stablebridge.indexer.domain.event.TransferDetectedEvent;
+import com.stablebridge.indexer.domain.model.Transfer;
+import com.stablebridge.indexer.testutil.TransferFixtures;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TransferEventMapperTest {
+
+    private final TransferEventMapper mapper = Mappers.getMapper(TransferEventMapper.class);
+
+    @Test
+    void toTransferEvent_mapsAllFieldsCorrectly() {
+        // given
+        TransferDetectedEvent event = TransferFixtures.aTransferDetectedEvent().build();
+        Transfer transfer = event.transfer();
+
+        TransferEvent expected = new TransferEvent(
+                transfer.txHash(),
+                transfer.fromAddress(),
+                transfer.toAddress(),
+                transfer.rawAmount(),
+                transfer.amount(),
+                transfer.decimals(),
+                transfer.tokenSymbol(),
+                transfer.tokenContractAddress(),
+                transfer.blockNumber(),
+                transfer.blockHash(),
+                transfer.transactionIndex(),
+                transfer.logIndex(),
+                "ETHEREUM",
+                "EVM",
+                transfer.timestamp(),
+                transfer.nativeTransfer(),
+                event.detectedAt());
+
+        // when
+        TransferEvent actual = mapper.toTransferEvent(event);
+
+        // then
+        assertThat(actual)
+                .usingRecursiveComparison()
+                .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+                .isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `KafkaTransferEventPublisher` as the infrastructure adapter for the `TransferEventPublisher` domain port
- Add `TransferEventMapper` (MapStruct) to map `TransferDetectedEvent` (domain) to `TransferEvent` (API DTO)
- Publish to per-chain Kafka topics (`transfer.events.<chainId>`) with `toAddress` as partition key for per-wallet ordering

## Design Decisions
- **Per-chain topics** (`transfer.events.ETHEREUM`, `transfer.events.POLYGON`, etc.) for fault isolation (ADR-9)
- **Key = toAddress** for per-wallet ordering, ensuring balance crediting consumers see events in order (ADR-11)
- **At-least-once delivery**: Kafka publish before Redis progress save (ADR-18)
- **Consumer dedup key**: `txHash + toAddress + networkId`

## Files Added
- `KafkaTransferEventPublisher.java` — `@Component` implementing `TransferEventPublisher` port
- `TransferEventMapper.java` — MapStruct mapper (package-private) for domain-to-API DTO mapping
- `KafkaTransferEventPublisherTest.java` — Unit tests (topic naming, key, batch, empty list)
- `TransferEventMapperTest.java` — Unit test verifying all field mappings including `chainId`/`networkType` string conversion

## Test plan
- [x] `KafkaTransferEventPublisherTest` — verifies correct topic (`transfer.events.ETHEREUM`), key (`toAddress`), and message payload
- [x] `KafkaTransferEventPublisherTest` — verifies per-chain topic naming with different `ChainId` (POLYGON)
- [x] `KafkaTransferEventPublisherTest` — verifies `publishAll` sends each event individually
- [x] `KafkaTransferEventPublisherTest` — verifies empty list produces no Kafka interactions
- [x] `TransferEventMapperTest` — verifies all fields mapped correctly (recursive comparison)
- [x] All ArchUnit hexagonal architecture rules pass
- [x] `./gradlew build` passes (unit tests + spotless + integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)