### PR TITLE
Add JPA persistence layer for wallet addresses (SBI-13)

### DIFF
--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/persistence/JpaWalletAddressRepository.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/persistence/JpaWalletAddressRepository.java
@@ -1,0 +1,18 @@
+package com.stablebridge.indexer.infrastructure.persistence;
+
+import com.stablebridge.indexer.domain.model.NetworkType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface JpaWalletAddressRepository extends JpaRepository<WalletAddressEntity, Long> {
+
+    Optional<WalletAddressEntity> findByAddressAndNetworkType(String address, NetworkType networkType);
+
+    List<WalletAddressEntity> findAllByNetworkType(NetworkType networkType);
+
+    boolean existsByAddressAndNetworkType(String address, NetworkType networkType);
+
+    void deleteByAddressAndNetworkType(String address, NetworkType networkType);
+}

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/persistence/WalletAddressEntity.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/persistence/WalletAddressEntity.java
@@ -1,0 +1,62 @@
+package com.stablebridge.indexer.infrastructure.persistence;
+
+import com.stablebridge.indexer.domain.model.NetworkType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "wallet_addresses")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WalletAddressEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String address;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "network_type")
+    private NetworkType networkType;
+
+    private String label;
+
+    private boolean active;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @PrePersist
+    void prePersist() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        this.updatedAt = Instant.now();
+    }
+}

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/persistence/WalletAddressMapper.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/persistence/WalletAddressMapper.java
@@ -1,0 +1,12 @@
+package com.stablebridge.indexer.infrastructure.persistence;
+
+import com.stablebridge.indexer.domain.model.WalletAddress;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface WalletAddressMapper {
+
+    WalletAddress toDomain(WalletAddressEntity entity);
+
+    WalletAddressEntity toEntity(WalletAddress domain);
+}

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/persistence/WalletAddressPersistenceAdapter.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/persistence/WalletAddressPersistenceAdapter.java
@@ -1,0 +1,50 @@
+package com.stablebridge.indexer.infrastructure.persistence;
+
+import com.stablebridge.indexer.domain.model.NetworkType;
+import com.stablebridge.indexer.domain.model.WalletAddress;
+import com.stablebridge.indexer.domain.port.WalletAddressRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class WalletAddressPersistenceAdapter implements WalletAddressRepository {
+
+    private final JpaWalletAddressRepository jpaRepository;
+    private final WalletAddressMapper mapper;
+
+    @Override
+    public WalletAddress save(WalletAddress walletAddress) {
+        WalletAddressEntity entity = mapper.toEntity(walletAddress);
+        WalletAddressEntity saved = jpaRepository.save(entity);
+        return mapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<WalletAddress> findByAddressAndNetworkType(String address, NetworkType networkType) {
+        return jpaRepository.findByAddressAndNetworkType(address, networkType)
+                .map(mapper::toDomain);
+    }
+
+    @Override
+    public List<WalletAddress> findAllByNetworkType(NetworkType networkType) {
+        return jpaRepository.findAllByNetworkType(networkType).stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public boolean existsByAddressAndNetworkType(String address, NetworkType networkType) {
+        return jpaRepository.existsByAddressAndNetworkType(address, networkType);
+    }
+
+    @Override
+    @Transactional
+    public void deleteByAddressAndNetworkType(String address, NetworkType networkType) {
+        jpaRepository.deleteByAddressAndNetworkType(address, networkType);
+    }
+}

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/persistence/WalletAddressMapperTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/persistence/WalletAddressMapperTest.java
@@ -1,0 +1,61 @@
+package com.stablebridge.indexer.infrastructure.persistence;
+
+import com.stablebridge.indexer.domain.model.NetworkType;
+import com.stablebridge.indexer.domain.model.WalletAddress;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.stablebridge.indexer.testutil.WalletAddressFixtures.DEFAULT_ADDRESS;
+import static com.stablebridge.indexer.testutil.WalletAddressFixtures.DEFAULT_CREATED_AT;
+import static com.stablebridge.indexer.testutil.WalletAddressFixtures.DEFAULT_ID;
+import static com.stablebridge.indexer.testutil.WalletAddressFixtures.DEFAULT_LABEL;
+import static com.stablebridge.indexer.testutil.WalletAddressFixtures.DEFAULT_UPDATED_AT;
+import static com.stablebridge.indexer.testutil.WalletAddressFixtures.aWalletAddress;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WalletAddressMapperTest {
+
+    private final WalletAddressMapper mapper = new WalletAddressMapperImpl();
+
+    @Test
+    @DisplayName("toDomain maps entity fields to domain record")
+    void toDomain_maps_entity_to_domain() {
+        WalletAddressEntity entity = WalletAddressEntity.builder()
+                .id(DEFAULT_ID)
+                .address(DEFAULT_ADDRESS)
+                .networkType(NetworkType.EVM)
+                .label(DEFAULT_LABEL)
+                .active(true)
+                .createdAt(DEFAULT_CREATED_AT)
+                .updatedAt(DEFAULT_UPDATED_AT)
+                .build();
+
+        WalletAddress actual = mapper.toDomain(entity);
+
+        WalletAddress expected = aWalletAddress().build();
+        assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("toEntity maps domain record to entity fields")
+    void toEntity_maps_domain_to_entity() {
+        WalletAddress domain = aWalletAddress().build();
+
+        WalletAddressEntity actual = mapper.toEntity(domain);
+
+        WalletAddressEntity expected = WalletAddressEntity.builder()
+                .id(DEFAULT_ID)
+                .address(DEFAULT_ADDRESS)
+                .networkType(NetworkType.EVM)
+                .label(DEFAULT_LABEL)
+                .active(true)
+                .createdAt(DEFAULT_CREATED_AT)
+                .updatedAt(DEFAULT_UPDATED_AT)
+                .build();
+        assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+}

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/persistence/WalletAddressPersistenceAdapterTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/persistence/WalletAddressPersistenceAdapterTest.java
@@ -1,0 +1,132 @@
+package com.stablebridge.indexer.infrastructure.persistence;
+
+import com.stablebridge.indexer.domain.model.NetworkType;
+import com.stablebridge.indexer.domain.model.WalletAddress;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.stablebridge.indexer.testutil.WalletAddressFixtures.DEFAULT_ADDRESS;
+import static com.stablebridge.indexer.testutil.WalletAddressFixtures.DEFAULT_CREATED_AT;
+import static com.stablebridge.indexer.testutil.WalletAddressFixtures.DEFAULT_ID;
+import static com.stablebridge.indexer.testutil.WalletAddressFixtures.DEFAULT_LABEL;
+import static com.stablebridge.indexer.testutil.WalletAddressFixtures.DEFAULT_UPDATED_AT;
+import static com.stablebridge.indexer.testutil.WalletAddressFixtures.aWalletAddress;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class WalletAddressPersistenceAdapterTest {
+
+    @Mock
+    private JpaWalletAddressRepository jpaRepository;
+
+    @Mock
+    private WalletAddressMapper mapper;
+
+    @InjectMocks
+    private WalletAddressPersistenceAdapter adapter;
+
+    @Test
+    @DisplayName("save maps to entity, persists, and maps back to domain")
+    void save_persists_and_returns_domain() {
+        WalletAddress domain = aWalletAddress().build();
+        WalletAddressEntity entity = anEntity();
+        WalletAddressEntity savedEntity = anEntity();
+        WalletAddress savedDomain = aWalletAddress().build();
+
+        given(mapper.toEntity(domain)).willReturn(entity);
+        given(jpaRepository.save(entity)).willReturn(savedEntity);
+        given(mapper.toDomain(savedEntity)).willReturn(savedDomain);
+
+        WalletAddress actual = adapter.save(domain);
+
+        assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(savedDomain);
+        then(mapper).should().toEntity(domain);
+        then(jpaRepository).should().save(entity);
+        then(mapper).should().toDomain(savedEntity);
+    }
+
+    @Test
+    @DisplayName("findByAddressAndNetworkType delegates and maps result")
+    void findByAddressAndNetworkType_returns_mapped_domain() {
+        WalletAddressEntity entity = anEntity();
+        WalletAddress domain = aWalletAddress().build();
+
+        given(jpaRepository.findByAddressAndNetworkType(DEFAULT_ADDRESS, NetworkType.EVM))
+                .willReturn(Optional.of(entity));
+        given(mapper.toDomain(entity)).willReturn(domain);
+
+        Optional<WalletAddress> actual = adapter.findByAddressAndNetworkType(DEFAULT_ADDRESS, NetworkType.EVM);
+
+        WalletAddress expected = aWalletAddress().build();
+        assertThat(actual)
+                .isPresent()
+                .hasValueSatisfying(value ->
+                        assertThat(value)
+                                .usingRecursiveComparison()
+                                .isEqualTo(expected));
+        then(jpaRepository).should().findByAddressAndNetworkType(DEFAULT_ADDRESS, NetworkType.EVM);
+    }
+
+    @Test
+    @DisplayName("findAllByNetworkType delegates and maps list")
+    void findAllByNetworkType_returns_mapped_list() {
+        WalletAddressEntity entity = anEntity();
+        WalletAddress domain = aWalletAddress().build();
+
+        given(jpaRepository.findAllByNetworkType(NetworkType.EVM)).willReturn(List.of(entity));
+        given(mapper.toDomain(entity)).willReturn(domain);
+
+        List<WalletAddress> actual = adapter.findAllByNetworkType(NetworkType.EVM);
+
+        WalletAddress expected = aWalletAddress().build();
+        assertThat(actual)
+                .hasSize(1)
+                .first()
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+        then(jpaRepository).should().findAllByNetworkType(NetworkType.EVM);
+    }
+
+    @Test
+    @DisplayName("existsByAddressAndNetworkType delegates directly")
+    void existsByAddressAndNetworkType_delegates() {
+        given(jpaRepository.existsByAddressAndNetworkType(DEFAULT_ADDRESS, NetworkType.EVM))
+                .willReturn(true);
+
+        boolean actual = adapter.existsByAddressAndNetworkType(DEFAULT_ADDRESS, NetworkType.EVM);
+
+        assertThat(actual).isTrue();
+        then(jpaRepository).should().existsByAddressAndNetworkType(DEFAULT_ADDRESS, NetworkType.EVM);
+    }
+
+    @Test
+    @DisplayName("deleteByAddressAndNetworkType delegates to JPA repository")
+    void deleteByAddressAndNetworkType_delegates() {
+        adapter.deleteByAddressAndNetworkType(DEFAULT_ADDRESS, NetworkType.EVM);
+
+        then(jpaRepository).should().deleteByAddressAndNetworkType(DEFAULT_ADDRESS, NetworkType.EVM);
+    }
+
+    private static WalletAddressEntity anEntity() {
+        return WalletAddressEntity.builder()
+                .id(DEFAULT_ID)
+                .address(DEFAULT_ADDRESS)
+                .networkType(NetworkType.EVM)
+                .label(DEFAULT_LABEL)
+                .active(true)
+                .createdAt(DEFAULT_CREATED_AT)
+                .updatedAt(DEFAULT_UPDATED_AT)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `WalletAddressEntity` JPA entity with `@PrePersist`/`@PreUpdate` lifecycle callbacks for timestamp management
- Add `JpaWalletAddressRepository` Spring Data interface with derived query methods (find, exists, delete by address+networkType)
- Add `WalletAddressMapper` MapStruct interface for bidirectional domain-entity mapping
- Add `WalletAddressPersistenceAdapter` implementing the domain `WalletAddressRepository` port with `@Transactional` delete

## Test plan
- [x] `WalletAddressMapperTest` — verifies both `toDomain` and `toEntity` mapping directions using recursive comparison
- [x] `WalletAddressPersistenceAdapterTest` — verifies all 5 adapter methods with BDDMockito, actual values (no generic matchers), and `WalletAddressFixtures`
- [x] All ArchUnit rules pass (hexagonal architecture, no JPA in domain, domain ports are interfaces)
- [x] `./gradlew build` passes (17 tests green)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)