### PR TITLE
SBI-10: Add GuavaBloomAddressFilter — in-memory bloom fallback

### DIFF
--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/application/config/GuavaBloomAutoConfiguration.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/application/config/GuavaBloomAutoConfiguration.java
@@ -1,0 +1,32 @@
+package com.stablebridge.indexer.application.config;
+
+import com.stablebridge.indexer.application.properties.BloomProperties;
+import com.stablebridge.indexer.domain.port.WalletAddressRepository;
+import com.stablebridge.indexer.infrastructure.bloom.GuavaBloomAddressFilter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Auto-configuration for the in-memory Guava-based bloom filter.
+ *
+ * <p>Activated when {@code indexer.bloom.backend=memory}. This bridges the application
+ * configuration layer ({@link BloomProperties}) with the infrastructure adapter
+ * ({@link GuavaBloomAddressFilter}), keeping the infrastructure layer free of
+ * application-layer dependencies (hexagonal architecture).
+ */
+@Configuration
+@ConditionalOnProperty(name = "indexer.bloom.backend", havingValue = "memory")
+public class GuavaBloomAutoConfiguration {
+
+    @Bean
+    GuavaBloomAddressFilter guavaBloomAddressFilter(
+            BloomProperties bloomProperties,
+            WalletAddressRepository walletAddressRepository) {
+        return new GuavaBloomAddressFilter(
+                bloomProperties.expectedInsertions(),
+                bloomProperties.errorRate(),
+                walletAddressRepository
+        );
+    }
+}

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/bloom/GuavaBloomAddressFilter.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/bloom/GuavaBloomAddressFilter.java
@@ -1,0 +1,87 @@
+package com.stablebridge.indexer.infrastructure.bloom;
+
+import com.google.common.hash.BloomFilter;
+import com.google.common.hash.Funnels;
+import com.stablebridge.indexer.domain.model.NetworkType;
+import com.stablebridge.indexer.domain.port.AddressFilter;
+import com.stablebridge.indexer.domain.port.WalletAddressRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory Guava-based implementation of {@link AddressFilter} for local development
+ * and environments where RedisBloom is not available.
+ *
+ * <p>Uses {@link BloomFilter} from Google Guava with per-{@link NetworkType} filters
+ * stored in a {@link ConcurrentHashMap}. The bloom filter provides sub-millisecond
+ * probabilistic lookups; positive results must always be confirmed against the database
+ * via {@link WalletAddressRepository#existsByAddressAndNetworkType(String, NetworkType)}.
+ *
+ * <p>Activated when {@code indexer.bloom.backend=memory} via
+ * {@code GuavaBloomAutoConfiguration} in the application layer.
+ *
+ * <p>Limitations:
+ * <ul>
+ *   <li>Bloom filters do not support element removal. {@link #remove(String, NetworkType)}
+ *       logs a warning and is a no-op on the bloom filter itself.</li>
+ *   <li>Filter state is lost on application restart (in-memory only).</li>
+ * </ul>
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class GuavaBloomAddressFilter implements AddressFilter {
+
+    private final long expectedInsertions;
+    private final double errorRate;
+    private final WalletAddressRepository walletAddressRepository;
+
+    private final ConcurrentHashMap<NetworkType, BloomFilter<String>> filters = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    void initialize() {
+        for (NetworkType networkType : NetworkType.values()) {
+            filters.computeIfAbsent(networkType, this::createBloomFilter);
+        }
+        log.info("Initialized Guava bloom filters for all network types — expectedInsertions={}, errorRate={}",
+                expectedInsertions, errorRate);
+    }
+
+    @Override
+    public boolean mightContain(String address, NetworkType networkType) {
+        return getOrCreateFilter(networkType).mightContain(address);
+    }
+
+    @Override
+    public boolean contains(String address, NetworkType networkType) {
+        return walletAddressRepository.existsByAddressAndNetworkType(address, networkType);
+    }
+
+    @Override
+    public void add(String address, NetworkType networkType) {
+        getOrCreateFilter(networkType).put(address);
+        log.debug("Added address to Guava bloom filter — networkType={}, address={}", networkType, address);
+    }
+
+    @Override
+    public void remove(String address, NetworkType networkType) {
+        log.warn("Bloom filters do not support removal — address will remain in bloom filter until rebuild. "
+                + "networkType={}, address={}", networkType, address);
+    }
+
+    private BloomFilter<String> getOrCreateFilter(NetworkType networkType) {
+        return filters.computeIfAbsent(networkType, this::createBloomFilter);
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    private BloomFilter<String> createBloomFilter(NetworkType networkType) {
+        return BloomFilter.create(
+                Funnels.stringFunnel(StandardCharsets.UTF_8),
+                expectedInsertions,
+                errorRate
+        );
+    }
+}

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/bloom/GuavaBloomAddressFilterTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/bloom/GuavaBloomAddressFilterTest.java
@@ -1,0 +1,146 @@
+package com.stablebridge.indexer.infrastructure.bloom;
+
+import com.stablebridge.indexer.domain.model.NetworkType;
+import com.stablebridge.indexer.domain.port.WalletAddressRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GuavaBloomAddressFilter")
+class GuavaBloomAddressFilterTest {
+
+    private static final String ADDRESS = "0xabcdef1234567890abcdef1234567890abcdef12";
+    private static final String UNKNOWN_ADDRESS = "0x0000000000000000000000000000000000000000";
+    private static final NetworkType NETWORK_TYPE = NetworkType.EVM;
+    private static final long EXPECTED_INSERTIONS = 1_000L;
+    private static final double ERROR_RATE = 0.001;
+
+    @Mock
+    private WalletAddressRepository walletAddressRepository;
+
+    private GuavaBloomAddressFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new GuavaBloomAddressFilter(EXPECTED_INSERTIONS, ERROR_RATE, walletAddressRepository);
+        filter.initialize();
+    }
+
+    @Nested
+    @DisplayName("mightContain")
+    class MightContain {
+
+        @Test
+        @DisplayName("returns false for address never added")
+        void returnsFalseForUnknownAddress() {
+            boolean result = filter.mightContain(UNKNOWN_ADDRESS, NETWORK_TYPE);
+
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("returns true for address that was added")
+        void returnsTrueForAddedAddress() {
+            filter.add(ADDRESS, NETWORK_TYPE);
+
+            boolean result = filter.mightContain(ADDRESS, NETWORK_TYPE);
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("filters are scoped per network type")
+        void filtersAreScopedPerNetworkType() {
+            filter.add(ADDRESS, NetworkType.EVM);
+
+            boolean result = filter.mightContain(ADDRESS, NetworkType.SOLANA);
+
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("contains")
+    class Contains {
+
+        @Test
+        @DisplayName("delegates to WalletAddressRepository when address exists")
+        void delegatesToRepositoryWhenExists() {
+            given(walletAddressRepository.existsByAddressAndNetworkType(ADDRESS, NETWORK_TYPE))
+                    .willReturn(true);
+
+            boolean result = filter.contains(ADDRESS, NETWORK_TYPE);
+
+            assertThat(result).isTrue();
+            then(walletAddressRepository).should()
+                    .existsByAddressAndNetworkType(ADDRESS, NETWORK_TYPE);
+        }
+
+        @Test
+        @DisplayName("delegates to WalletAddressRepository when address does not exist")
+        void delegatesToRepositoryWhenNotExists() {
+            given(walletAddressRepository.existsByAddressAndNetworkType(UNKNOWN_ADDRESS, NETWORK_TYPE))
+                    .willReturn(false);
+
+            boolean result = filter.contains(UNKNOWN_ADDRESS, NETWORK_TYPE);
+
+            assertThat(result).isFalse();
+            then(walletAddressRepository).should()
+                    .existsByAddressAndNetworkType(UNKNOWN_ADDRESS, NETWORK_TYPE);
+        }
+    }
+
+    @Nested
+    @DisplayName("add")
+    class Add {
+
+        @Test
+        @DisplayName("makes address detectable by mightContain")
+        void makesAddressDetectable() {
+            filter.add(ADDRESS, NETWORK_TYPE);
+
+            boolean result = filter.mightContain(ADDRESS, NETWORK_TYPE);
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("supports adding to different network types independently")
+        void supportsMultipleNetworkTypes() {
+            filter.add(ADDRESS, NetworkType.EVM);
+            filter.add(ADDRESS, NetworkType.SOLANA);
+
+            boolean evmResult = filter.mightContain(ADDRESS, NetworkType.EVM);
+            boolean solanaResult = filter.mightContain(ADDRESS, NetworkType.SOLANA);
+
+            assertThat(evmResult).isTrue();
+            assertThat(solanaResult).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("remove")
+    class Remove {
+
+        @Test
+        @DisplayName("is a no-op — bloom filters do not support removal")
+        void isNoOp() {
+            filter.add(ADDRESS, NETWORK_TYPE);
+
+            filter.remove(ADDRESS, NETWORK_TYPE);
+
+            // Bloom filters cannot remove elements, so address is still detectable
+            boolean result = filter.mightContain(ADDRESS, NETWORK_TYPE);
+            assertThat(result).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **GuavaBloomAddressFilter** implements the `AddressFilter` domain port using Google Guava `BloomFilter` for in-memory, sub-millisecond address matching without Redis dependency
- Per-`NetworkType` bloom filters stored in a `ConcurrentHashMap` — one filter covers all chains of the same type (EVM, SOLANA, BITCOIN)
- `contains()` delegates to `WalletAddressRepository.existsByAddressAndNetworkType()` for DB confirmation, enforcing the bloom + DB confirm pattern for financial correctness
- `remove()` is a no-op with a warning log since bloom filters do not support element removal
- **GuavaBloomAutoConfiguration** in `application.config` bridges `BloomProperties` to the infrastructure adapter, keeping hexagonal architecture boundaries clean (infrastructure does not depend on application layer)
- Activated via `@ConditionalOnProperty(name = "indexer.bloom.backend", havingValue = "memory")`

## Test plan
- [x] 8 unit tests covering all `AddressFilter` contract methods
- [x] Uses real Guava `BloomFilter` (no mocking for bloom itself)
- [x] Mocks `WalletAddressRepository` for `contains()` DB delegation
- [x] Verifies per-`NetworkType` filter isolation
- [x] Verifies `remove()` is a no-op (address still detectable after remove)
- [x] All 18 tests pass (10 ArchUnit + 8 GuavaBloomAddressFilter)
- [x] `./gradlew build` passes clean

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)