### PR TITLE
Enforce coding standards across Phase 1 & 2 codebase (SBI-63)

### DIFF
--- a/stablebridge-indexer-api/src/main/java/com/stablebridge/indexer/api/ErrorResponse.java
+++ b/stablebridge-indexer-api/src/main/java/com/stablebridge/indexer/api/ErrorResponse.java
@@ -1,7 +1,10 @@
 package com.stablebridge.indexer.api;
 
+import lombok.Builder;
+
 import java.time.Instant;
 
+@Builder
 public record ErrorResponse(
         int status,
         String error,

--- a/stablebridge-indexer-api/src/main/java/com/stablebridge/indexer/api/IndexerStatusResponse.java
+++ b/stablebridge-indexer-api/src/main/java/com/stablebridge/indexer/api/IndexerStatusResponse.java
@@ -1,5 +1,8 @@
 package com.stablebridge.indexer.api;
 
+import lombok.Builder;
+
+@Builder
 public record IndexerStatusResponse(
         String chainId,
         String networkType,

--- a/stablebridge-indexer-api/src/main/java/com/stablebridge/indexer/api/TransferEvent.java
+++ b/stablebridge-indexer-api/src/main/java/com/stablebridge/indexer/api/TransferEvent.java
@@ -1,8 +1,11 @@
 package com.stablebridge.indexer.api;
 
+import lombok.Builder;
+
 import java.math.BigDecimal;
 import java.time.Instant;
 
+@Builder
 public record TransferEvent(
         String txHash,
         String fromAddress,

--- a/stablebridge-indexer-api/src/main/java/com/stablebridge/indexer/api/WalletAddressRequest.java
+++ b/stablebridge-indexer-api/src/main/java/com/stablebridge/indexer/api/WalletAddressRequest.java
@@ -2,7 +2,9 @@ package com.stablebridge.indexer.api;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
+@Builder
 public record WalletAddressRequest(
         @NotBlank String address,
         @NotNull NetworkType networkType,

--- a/stablebridge-indexer-api/src/main/java/com/stablebridge/indexer/api/WalletAddressResponse.java
+++ b/stablebridge-indexer-api/src/main/java/com/stablebridge/indexer/api/WalletAddressResponse.java
@@ -1,7 +1,10 @@
 package com.stablebridge.indexer.api;
 
+import lombok.Builder;
+
 import java.time.Instant;
 
+@Builder
 public record WalletAddressResponse(
         Long id,
         String address,

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/application/config/GuavaBloomAutoConfiguration.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/application/config/GuavaBloomAutoConfiguration.java
@@ -7,14 +7,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/**
- * Auto-configuration for the in-memory Guava-based bloom filter.
- *
- * <p>Activated when {@code indexer.bloom.backend=memory}. This bridges the application
- * configuration layer ({@link BloomProperties}) with the infrastructure adapter
- * ({@link GuavaBloomAddressFilter}), keeping the infrastructure layer free of
- * application-layer dependencies (hexagonal architecture).
- */
 @Configuration
 @ConditionalOnProperty(name = "indexer.bloom.backend", havingValue = "memory")
 public class GuavaBloomAutoConfiguration {

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/application/config/RedisBloomAutoConfiguration.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/application/config/RedisBloomAutoConfiguration.java
@@ -8,14 +8,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
-/**
- * Auto-configuration for the Redis Bloom filter-backed address filter.
- *
- * <p>Activated when {@code indexer.bloom.backend=redis} (the production default).
- * This bridges the application configuration layer ({@link BloomProperties}) with the
- * infrastructure adapter ({@link RedisBloomAddressFilter}), keeping the infrastructure
- * layer free of application-layer dependencies (hexagonal architecture).
- */
 @Configuration
 @ConditionalOnProperty(name = "indexer.bloom.backend", havingValue = "redis")
 public class RedisBloomAutoConfiguration {

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/security/ApiKeyAuthFilter.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/security/ApiKeyAuthFilter.java
@@ -5,6 +5,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -16,6 +17,7 @@ import java.time.Instant;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 @Slf4j
+@RequiredArgsConstructor
 public class ApiKeyAuthFilter extends OncePerRequestFilter {
 
     static final String API_KEY_HEADER = "X-API-Key";
@@ -24,11 +26,6 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
 
     private final String expectedApiKey;
     private final ObjectMapper objectMapper;
-
-    public ApiKeyAuthFilter(String expectedApiKey, ObjectMapper objectMapper) {
-        this.expectedApiKey = expectedApiKey;
-        this.objectMapper = objectMapper;
-    }
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/application/controller/StatusControllerTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/application/controller/StatusControllerTest.java
@@ -1,8 +1,5 @@
 package com.stablebridge.indexer.application.controller;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.stablebridge.indexer.api.BloomStatusResponse;
 import com.stablebridge.indexer.api.ErrorResponse;
 import com.stablebridge.indexer.api.IndexerStatusResponse;
@@ -16,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
 import java.util.Optional;
@@ -40,7 +38,8 @@ class StatusControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockitoBean
     private StatusQueryHandler statusQueryHandler;
@@ -80,7 +79,7 @@ class StatusControllerTest {
 
             var actual = objectMapper.readValue(
                     result.getResponse().getContentAsString(),
-                    new TypeReference<List<IndexerStatusResponse>>() {});
+                    objectMapper.getTypeFactory().constructCollectionType(List.class, IndexerStatusResponse.class));
             var expected = List.of(
                     new IndexerStatusResponse(
                             ETHEREUM_CHAIN, "EVM", "STOPPED",

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/application/controller/WalletControllerTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/application/controller/WalletControllerTest.java
@@ -1,5 +1,6 @@
 package com.stablebridge.indexer.application.controller;
 
+import com.stablebridge.indexer.api.NetworkType;
 import com.stablebridge.indexer.api.WalletAddressRequest;
 import com.stablebridge.indexer.api.WalletAddressResponse;
 import com.stablebridge.indexer.application.config.SecurityAutoConfiguration;
@@ -65,12 +66,12 @@ class WalletControllerTest {
         void returnsCreatedWhenWalletAdded() throws Exception {
             var request = new WalletAddressRequest(
                     DEFAULT_ADDRESS,
-                    com.stablebridge.indexer.api.NetworkType.EVM,
+                    NetworkType.EVM,
                     DEFAULT_LABEL);
             var savedWallet = aWalletAddress().build();
             var expectedResponse = aWalletAddressResponse();
 
-            given(mapper.toDomain(com.stablebridge.indexer.api.NetworkType.EVM))
+            given(mapper.toDomain(NetworkType.EVM))
                     .willReturn(EVM);
             given(walletCommandHandler.addWallet(DEFAULT_ADDRESS, EVM, DEFAULT_LABEL))
                     .willReturn(savedWallet);
@@ -94,7 +95,7 @@ class WalletControllerTest {
         void returnsUnauthorizedWithoutApiKey() throws Exception {
             var request = new WalletAddressRequest(
                     DEFAULT_ADDRESS,
-                    com.stablebridge.indexer.api.NetworkType.EVM,
+                    NetworkType.EVM,
                     DEFAULT_LABEL);
 
             mockMvc.perform(post("/api/v1/wallets")
@@ -108,7 +109,7 @@ class WalletControllerTest {
         void returnsBadRequestWhenAddressBlank() throws Exception {
             var request = new WalletAddressRequest(
                     "",
-                    com.stablebridge.indexer.api.NetworkType.EVM,
+                    NetworkType.EVM,
                     DEFAULT_LABEL);
 
             mockMvc.perform(post("/api/v1/wallets")
@@ -142,14 +143,14 @@ class WalletControllerTest {
         void returnsCreatedWhenBatchAdded() throws Exception {
             var request = new WalletAddressRequest(
                     DEFAULT_ADDRESS,
-                    com.stablebridge.indexer.api.NetworkType.EVM,
+                    NetworkType.EVM,
                     DEFAULT_LABEL);
             var savedWallet = aWalletAddress().build();
             var expectedResponse = aWalletAddressResponse();
             var expectedTuples = List.of(
                     new WalletAddressTuple(DEFAULT_ADDRESS, EVM, DEFAULT_LABEL));
 
-            given(mapper.toDomain(com.stablebridge.indexer.api.NetworkType.EVM))
+            given(mapper.toDomain(NetworkType.EVM))
                     .willReturn(EVM);
             given(walletCommandHandler.addWalletsBatch(expectedTuples))
                     .willReturn(List.of(savedWallet));
@@ -174,7 +175,7 @@ class WalletControllerTest {
         void returnsUnauthorizedWithoutApiKey() throws Exception {
             var request = new WalletAddressRequest(
                     DEFAULT_ADDRESS,
-                    com.stablebridge.indexer.api.NetworkType.EVM,
+                    NetworkType.EVM,
                     DEFAULT_LABEL);
 
             mockMvc.perform(post("/api/v1/wallets/batch")
@@ -194,7 +195,7 @@ class WalletControllerTest {
             var wallet = aWalletAddress().build();
             var expectedResponse = aWalletAddressResponse();
 
-            given(mapper.toDomain(com.stablebridge.indexer.api.NetworkType.EVM))
+            given(mapper.toDomain(NetworkType.EVM))
                     .willReturn(EVM);
             given(walletCommandHandler.listWallets(EVM))
                     .willReturn(List.of(wallet));
@@ -237,7 +238,7 @@ class WalletControllerTest {
         @Test
         @DisplayName("returns 204 No Content when wallet is removed with valid API key")
         void returnsNoContentWhenWalletRemoved() throws Exception {
-            given(mapper.toDomain(com.stablebridge.indexer.api.NetworkType.EVM))
+            given(mapper.toDomain(NetworkType.EVM))
                     .willReturn(EVM);
 
             mockMvc.perform(delete("/api/v1/wallets/{address}", DEFAULT_ADDRESS)

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/bloom/GuavaBloomAddressFilterTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/bloom/GuavaBloomAddressFilterTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static com.stablebridge.indexer.domain.model.NetworkType.EVM;
+import static com.stablebridge.indexer.domain.model.NetworkType.SOLANA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -20,7 +22,7 @@ class GuavaBloomAddressFilterTest {
 
     private static final String ADDRESS = "0xabcdef1234567890abcdef1234567890abcdef12";
     private static final String UNKNOWN_ADDRESS = "0x0000000000000000000000000000000000000000";
-    private static final NetworkType NETWORK_TYPE = NetworkType.EVM;
+    private static final NetworkType NETWORK_TYPE = EVM;
     private static final long EXPECTED_INSERTIONS = 1_000L;
     private static final double ERROR_RATE = 0.001;
 
@@ -60,9 +62,9 @@ class GuavaBloomAddressFilterTest {
         @Test
         @DisplayName("filters are scoped per network type")
         void filtersAreScopedPerNetworkType() {
-            filter.add(ADDRESS, NetworkType.EVM);
+            filter.add(ADDRESS, EVM);
 
-            boolean result = filter.mightContain(ADDRESS, NetworkType.SOLANA);
+            boolean result = filter.mightContain(ADDRESS, SOLANA);
 
             assertThat(result).isFalse();
         }
@@ -116,11 +118,11 @@ class GuavaBloomAddressFilterTest {
         @Test
         @DisplayName("supports adding to different network types independently")
         void supportsMultipleNetworkTypes() {
-            filter.add(ADDRESS, NetworkType.EVM);
-            filter.add(ADDRESS, NetworkType.SOLANA);
+            filter.add(ADDRESS, EVM);
+            filter.add(ADDRESS, SOLANA);
 
-            boolean evmResult = filter.mightContain(ADDRESS, NetworkType.EVM);
-            boolean solanaResult = filter.mightContain(ADDRESS, NetworkType.SOLANA);
+            boolean evmResult = filter.mightContain(ADDRESS, EVM);
+            boolean solanaResult = filter.mightContain(ADDRESS, SOLANA);
 
             assertThat(evmResult).isTrue();
             assertThat(solanaResult).isTrue();

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/bloom/RedisBloomAddressFilterTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/bloom/RedisBloomAddressFilterTest.java
@@ -16,6 +16,8 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 
 import java.nio.charset.StandardCharsets;
 
+import static com.stablebridge.indexer.domain.model.NetworkType.EVM;
+import static com.stablebridge.indexer.domain.model.NetworkType.SOLANA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -26,7 +28,7 @@ import static org.mockito.Mockito.lenient;
 class RedisBloomAddressFilterTest {
 
     private static final String TEST_ADDRESS = "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18";
-    private static final NetworkType TEST_NETWORK = NetworkType.EVM;
+    private static final NetworkType TEST_NETWORK = EVM;
     private static final String BLOOM_KEY = "indexer:bloom:EVM";
     private static final byte[] BLOOM_KEY_BYTES = BLOOM_KEY.getBytes(StandardCharsets.UTF_8);
     private static final byte[] ADDRESS_BYTES = TEST_ADDRESS.getBytes(StandardCharsets.UTF_8);
@@ -126,7 +128,7 @@ class RedisBloomAddressFilterTest {
             given(redisCommands.execute("BF.EXISTS", solanaKeyBytes, ADDRESS_BYTES))
                     .willReturn(1L);
 
-            boolean result = filter.mightContain(TEST_ADDRESS, NetworkType.SOLANA);
+            boolean result = filter.mightContain(TEST_ADDRESS, SOLANA);
 
             assertThat(result).isTrue();
         }

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/messaging/KafkaTransferEventPublisherTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/messaging/KafkaTransferEventPublisherTest.java
@@ -2,9 +2,6 @@ package com.stablebridge.indexer.infrastructure.messaging;
 
 import com.stablebridge.indexer.api.TransferEvent;
 import com.stablebridge.indexer.domain.event.TransferDetectedEvent;
-import com.stablebridge.indexer.domain.model.ChainId;
-import com.stablebridge.indexer.domain.model.Transfer;
-import com.stablebridge.indexer.testutil.TransferFixtures;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -15,6 +12,10 @@ import org.springframework.kafka.core.KafkaTemplate;
 import java.time.Instant;
 import java.util.List;
 
+import static com.stablebridge.indexer.domain.model.ChainId.POLYGON;
+import static com.stablebridge.indexer.testutil.TransferFixtures.DEFAULT_TO_ADDRESS;
+import static com.stablebridge.indexer.testutil.TransferFixtures.aTransfer;
+import static com.stablebridge.indexer.testutil.TransferFixtures.aTransferDetectedEvent;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
@@ -32,11 +33,10 @@ class KafkaTransferEventPublisherTest {
 
     @Test
     void publish_sendsToCorrectTopicWithToAddressKey() {
-        // given
-        TransferDetectedEvent event = TransferFixtures.aTransferDetectedEvent().build();
-        Transfer transfer = event.transfer();
+        var event = aTransferDetectedEvent().build();
+        var transfer = event.transfer();
 
-        TransferEvent expectedApiEvent = new TransferEvent(
+        var expectedApiEvent = new TransferEvent(
                 transfer.txHash(),
                 transfer.fromAddress(),
                 transfer.toAddress(),
@@ -57,28 +57,25 @@ class KafkaTransferEventPublisherTest {
 
         given(transferEventMapper.toTransferEvent(event)).willReturn(expectedApiEvent);
 
-        // when
         publisher.publish(event);
 
-        // then
         then(kafkaTemplate).should().send(
                 "transfer.events.ETHEREUM",
-                TransferFixtures.DEFAULT_TO_ADDRESS,
+                DEFAULT_TO_ADDRESS,
                 expectedApiEvent);
     }
 
     @Test
     void publish_usesChainIdForTopicName() {
-        // given
-        Transfer polygonTransfer = TransferFixtures.aTransfer()
-                .chainId(ChainId.POLYGON)
+        var polygonTransfer = aTransfer()
+                .chainId(POLYGON)
                 .build();
-        TransferDetectedEvent event = TransferDetectedEvent.builder()
+        var event = TransferDetectedEvent.builder()
                 .transfer(polygonTransfer)
                 .detectedAt(Instant.parse("2026-03-19T10:15:31Z"))
                 .build();
 
-        TransferEvent expectedApiEvent = new TransferEvent(
+        var expectedApiEvent = new TransferEvent(
                 polygonTransfer.txHash(),
                 polygonTransfer.fromAddress(),
                 polygonTransfer.toAddress(),
@@ -99,36 +96,33 @@ class KafkaTransferEventPublisherTest {
 
         given(transferEventMapper.toTransferEvent(event)).willReturn(expectedApiEvent);
 
-        // when
         publisher.publish(event);
 
-        // then
         then(kafkaTemplate).should().send(
                 "transfer.events.POLYGON",
-                TransferFixtures.DEFAULT_TO_ADDRESS,
+                DEFAULT_TO_ADDRESS,
                 expectedApiEvent);
     }
 
     @Test
     void publishAll_sendsEachEventIndividually() {
-        // given
-        Transfer firstTransfer = TransferFixtures.aTransfer()
+        var firstTransfer = aTransfer()
                 .toAddress("0xfirst1234567890abcdef1234567890abcdef1234")
                 .build();
-        Transfer secondTransfer = TransferFixtures.aTransfer()
+        var secondTransfer = aTransfer()
                 .toAddress("0xsecond234567890abcdef1234567890abcdef1234")
                 .build();
 
-        TransferDetectedEvent firstEvent = TransferDetectedEvent.builder()
+        var firstEvent = TransferDetectedEvent.builder()
                 .transfer(firstTransfer)
                 .detectedAt(Instant.parse("2026-03-19T10:15:31Z"))
                 .build();
-        TransferDetectedEvent secondEvent = TransferDetectedEvent.builder()
+        var secondEvent = TransferDetectedEvent.builder()
                 .transfer(secondTransfer)
                 .detectedAt(Instant.parse("2026-03-19T10:15:32Z"))
                 .build();
 
-        TransferEvent firstApiEvent = new TransferEvent(
+        var firstApiEvent = new TransferEvent(
                 firstTransfer.txHash(),
                 firstTransfer.fromAddress(),
                 firstTransfer.toAddress(),
@@ -147,7 +141,7 @@ class KafkaTransferEventPublisherTest {
                 firstTransfer.nativeTransfer(),
                 firstEvent.detectedAt());
 
-        TransferEvent secondApiEvent = new TransferEvent(
+        var secondApiEvent = new TransferEvent(
                 secondTransfer.txHash(),
                 secondTransfer.fromAddress(),
                 secondTransfer.toAddress(),
@@ -169,10 +163,8 @@ class KafkaTransferEventPublisherTest {
         given(transferEventMapper.toTransferEvent(firstEvent)).willReturn(firstApiEvent);
         given(transferEventMapper.toTransferEvent(secondEvent)).willReturn(secondApiEvent);
 
-        // when
         publisher.publishAll(List.of(firstEvent, secondEvent));
 
-        // then
         then(kafkaTemplate).should().send(
                 "transfer.events.ETHEREUM",
                 "0xfirst1234567890abcdef1234567890abcdef1234",

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/persistence/WalletAddressPersistenceAdapterTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/persistence/WalletAddressPersistenceAdapterTest.java
@@ -1,7 +1,5 @@
 package com.stablebridge.indexer.infrastructure.persistence;
 
-import com.stablebridge.indexer.domain.model.NetworkType;
-import com.stablebridge.indexer.domain.model.WalletAddress;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Optional;
 
+import static com.stablebridge.indexer.domain.model.NetworkType.EVM;
 import static com.stablebridge.indexer.testutil.WalletAddressFixtures.DEFAULT_ADDRESS;
 import static com.stablebridge.indexer.testutil.WalletAddressFixtures.DEFAULT_CREATED_AT;
 import static com.stablebridge.indexer.testutil.WalletAddressFixtures.DEFAULT_ID;
@@ -37,16 +36,16 @@ class WalletAddressPersistenceAdapterTest {
     @Test
     @DisplayName("save maps to entity, persists, and maps back to domain")
     void save_persists_and_returns_domain() {
-        WalletAddress domain = aWalletAddress().build();
-        WalletAddressEntity entity = anEntity();
-        WalletAddressEntity savedEntity = anEntity();
-        WalletAddress savedDomain = aWalletAddress().build();
+        var domain = aWalletAddress().build();
+        var entity = anEntity();
+        var savedEntity = anEntity();
+        var savedDomain = aWalletAddress().build();
 
         given(mapper.toEntity(domain)).willReturn(entity);
         given(jpaRepository.save(entity)).willReturn(savedEntity);
         given(mapper.toDomain(savedEntity)).willReturn(savedDomain);
 
-        WalletAddress actual = adapter.save(domain);
+        var actual = adapter.save(domain);
 
         assertThat(actual)
                 .usingRecursiveComparison()
@@ -59,70 +58,70 @@ class WalletAddressPersistenceAdapterTest {
     @Test
     @DisplayName("findByAddressAndNetworkType delegates and maps result")
     void findByAddressAndNetworkType_returns_mapped_domain() {
-        WalletAddressEntity entity = anEntity();
-        WalletAddress domain = aWalletAddress().build();
+        var entity = anEntity();
+        var domain = aWalletAddress().build();
 
-        given(jpaRepository.findByAddressAndNetworkType(DEFAULT_ADDRESS, NetworkType.EVM))
+        given(jpaRepository.findByAddressAndNetworkType(DEFAULT_ADDRESS, EVM))
                 .willReturn(Optional.of(entity));
         given(mapper.toDomain(entity)).willReturn(domain);
 
-        Optional<WalletAddress> actual = adapter.findByAddressAndNetworkType(DEFAULT_ADDRESS, NetworkType.EVM);
+        var actual = adapter.findByAddressAndNetworkType(DEFAULT_ADDRESS, EVM);
 
-        WalletAddress expected = aWalletAddress().build();
+        var expected = aWalletAddress().build();
         assertThat(actual)
                 .isPresent()
                 .hasValueSatisfying(value ->
                         assertThat(value)
                                 .usingRecursiveComparison()
                                 .isEqualTo(expected));
-        then(jpaRepository).should().findByAddressAndNetworkType(DEFAULT_ADDRESS, NetworkType.EVM);
+        then(jpaRepository).should().findByAddressAndNetworkType(DEFAULT_ADDRESS, EVM);
     }
 
     @Test
     @DisplayName("findAllByNetworkType delegates and maps list")
     void findAllByNetworkType_returns_mapped_list() {
-        WalletAddressEntity entity = anEntity();
-        WalletAddress domain = aWalletAddress().build();
+        var entity = anEntity();
+        var domain = aWalletAddress().build();
 
-        given(jpaRepository.findAllByNetworkType(NetworkType.EVM)).willReturn(List.of(entity));
+        given(jpaRepository.findAllByNetworkType(EVM)).willReturn(List.of(entity));
         given(mapper.toDomain(entity)).willReturn(domain);
 
-        List<WalletAddress> actual = adapter.findAllByNetworkType(NetworkType.EVM);
+        var actual = adapter.findAllByNetworkType(EVM);
 
-        WalletAddress expected = aWalletAddress().build();
+        var expected = aWalletAddress().build();
         assertThat(actual)
                 .hasSize(1)
                 .first()
                 .usingRecursiveComparison()
                 .isEqualTo(expected);
-        then(jpaRepository).should().findAllByNetworkType(NetworkType.EVM);
+        then(jpaRepository).should().findAllByNetworkType(EVM);
     }
 
     @Test
     @DisplayName("existsByAddressAndNetworkType delegates directly")
     void existsByAddressAndNetworkType_delegates() {
-        given(jpaRepository.existsByAddressAndNetworkType(DEFAULT_ADDRESS, NetworkType.EVM))
+        given(jpaRepository.existsByAddressAndNetworkType(DEFAULT_ADDRESS, EVM))
                 .willReturn(true);
 
-        boolean actual = adapter.existsByAddressAndNetworkType(DEFAULT_ADDRESS, NetworkType.EVM);
+        var actual = adapter.existsByAddressAndNetworkType(DEFAULT_ADDRESS, EVM);
 
         assertThat(actual).isTrue();
-        then(jpaRepository).should().existsByAddressAndNetworkType(DEFAULT_ADDRESS, NetworkType.EVM);
+        then(jpaRepository).should().existsByAddressAndNetworkType(DEFAULT_ADDRESS, EVM);
     }
 
     @Test
     @DisplayName("deleteByAddressAndNetworkType delegates to JPA repository")
     void deleteByAddressAndNetworkType_delegates() {
-        adapter.deleteByAddressAndNetworkType(DEFAULT_ADDRESS, NetworkType.EVM);
+        adapter.deleteByAddressAndNetworkType(DEFAULT_ADDRESS, EVM);
 
-        then(jpaRepository).should().deleteByAddressAndNetworkType(DEFAULT_ADDRESS, NetworkType.EVM);
+        then(jpaRepository).should().deleteByAddressAndNetworkType(DEFAULT_ADDRESS, EVM);
     }
 
     private static WalletAddressEntity anEntity() {
         return WalletAddressEntity.builder()
                 .id(DEFAULT_ID)
                 .address(DEFAULT_ADDRESS)
-                .networkType(NetworkType.EVM)
+                .networkType(EVM)
                 .label(DEFAULT_LABEL)
                 .active(true)
                 .createdAt(DEFAULT_CREATED_AT)

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/progress/RedisBlockProgressStoreTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/progress/RedisBlockProgressStoreTest.java
@@ -1,6 +1,5 @@
 package com.stablebridge.indexer.infrastructure.progress;
 
-import com.stablebridge.indexer.domain.model.ChainId;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -15,6 +14,13 @@ import org.springframework.data.redis.core.ZSetOperations;
 import java.util.OptionalLong;
 import java.util.Set;
 
+import static com.stablebridge.indexer.domain.model.ChainId.ARBITRUM;
+import static com.stablebridge.indexer.domain.model.ChainId.AVALANCHE;
+import static com.stablebridge.indexer.domain.model.ChainId.BASE;
+import static com.stablebridge.indexer.domain.model.ChainId.BSC;
+import static com.stablebridge.indexer.domain.model.ChainId.ETHEREUM;
+import static com.stablebridge.indexer.domain.model.ChainId.OPTIMISM;
+import static com.stablebridge.indexer.domain.model.ChainId.POLYGON;
 import static com.stablebridge.indexer.infrastructure.progress.RedisBlockProgressStore.FAILED_KEY_PREFIX;
 import static com.stablebridge.indexer.infrastructure.progress.RedisBlockProgressStore.PROGRESS_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,11 +52,11 @@ class RedisBlockProgressStoreTest {
         void shouldReturnBlockNumberWhenProgressExists() {
             // given
             given(redisTemplate.opsForHash()).willReturn(hashOperations);
-            given(hashOperations.get(PROGRESS_KEY, ChainId.ETHEREUM.name()))
+            given(hashOperations.get(PROGRESS_KEY, ETHEREUM.name()))
                     .willReturn("12345678");
 
             // when
-            OptionalLong result = store.getLastProcessedBlock(ChainId.ETHEREUM);
+            var result = store.getLastProcessedBlock(ETHEREUM);
 
             // then
             assertThat(result).isEqualTo(OptionalLong.of(12345678L));
@@ -61,11 +67,11 @@ class RedisBlockProgressStoreTest {
         void shouldReturnEmptyWhenNoProgressExists() {
             // given
             given(redisTemplate.opsForHash()).willReturn(hashOperations);
-            given(hashOperations.get(PROGRESS_KEY, ChainId.POLYGON.name()))
+            given(hashOperations.get(PROGRESS_KEY, POLYGON.name()))
                     .willReturn(null);
 
             // when
-            OptionalLong result = store.getLastProcessedBlock(ChainId.POLYGON);
+            var result = store.getLastProcessedBlock(POLYGON);
 
             // then
             assertThat(result).isEqualTo(OptionalLong.empty());
@@ -83,10 +89,10 @@ class RedisBlockProgressStoreTest {
             given(redisTemplate.opsForHash()).willReturn(hashOperations);
 
             // when
-            store.saveLastProcessedBlock(ChainId.ARBITRUM, 99887766L);
+            store.saveLastProcessedBlock(ARBITRUM, 99887766L);
 
             // then
-            then(hashOperations).should().put(PROGRESS_KEY, ChainId.ARBITRUM.name(), "99887766");
+            then(hashOperations).should().put(PROGRESS_KEY, ARBITRUM.name(), "99887766");
         }
     }
 
@@ -101,11 +107,11 @@ class RedisBlockProgressStoreTest {
             given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
 
             // when
-            store.addFailedBlock(ChainId.BASE, 55555L);
+            store.addFailedBlock(BASE, 55555L);
 
             // then
             then(zSetOperations).should().add(
-                    FAILED_KEY_PREFIX + ChainId.BASE.name(),
+                    FAILED_KEY_PREFIX + BASE.name(),
                     "55555",
                     55555.0
             );
@@ -121,11 +127,11 @@ class RedisBlockProgressStoreTest {
         void shouldReturnFailedBlockNumbers() {
             // given
             given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
-            given(zSetOperations.range(FAILED_KEY_PREFIX + ChainId.OPTIMISM.name(), 0, -1))
+            given(zSetOperations.range(FAILED_KEY_PREFIX + OPTIMISM.name(), 0, -1))
                     .willReturn(Set.of("100", "200", "300"));
 
             // when
-            Set<Long> result = store.getFailedBlocks(ChainId.OPTIMISM);
+            var result = store.getFailedBlocks(OPTIMISM);
 
             // then
             assertThat(result).isEqualTo(Set.of(100L, 200L, 300L));
@@ -136,11 +142,11 @@ class RedisBlockProgressStoreTest {
         void shouldReturnEmptySetWhenNoFailedBlocks() {
             // given
             given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
-            given(zSetOperations.range(FAILED_KEY_PREFIX + ChainId.BSC.name(), 0, -1))
+            given(zSetOperations.range(FAILED_KEY_PREFIX + BSC.name(), 0, -1))
                     .willReturn(null);
 
             // when
-            Set<Long> result = store.getFailedBlocks(ChainId.BSC);
+            var result = store.getFailedBlocks(BSC);
 
             // then
             assertThat(result).isEqualTo(Set.of());
@@ -151,11 +157,11 @@ class RedisBlockProgressStoreTest {
         void shouldReturnEmptySetWhenSortedSetIsEmpty() {
             // given
             given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
-            given(zSetOperations.range(FAILED_KEY_PREFIX + ChainId.AVALANCHE.name(), 0, -1))
+            given(zSetOperations.range(FAILED_KEY_PREFIX + AVALANCHE.name(), 0, -1))
                     .willReturn(Set.of());
 
             // when
-            Set<Long> result = store.getFailedBlocks(ChainId.AVALANCHE);
+            var result = store.getFailedBlocks(AVALANCHE);
 
             // then
             assertThat(result).isEqualTo(Set.of());
@@ -173,11 +179,11 @@ class RedisBlockProgressStoreTest {
             given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
 
             // when
-            store.removeFailedBlock(ChainId.ETHEREUM, 42000L);
+            store.removeFailedBlock(ETHEREUM, 42000L);
 
             // then
             then(zSetOperations).should().remove(
-                    FAILED_KEY_PREFIX + ChainId.ETHEREUM.name(),
+                    FAILED_KEY_PREFIX + ETHEREUM.name(),
                     "42000"
             );
         }


### PR DESCRIPTION
## Summary

- Add `@Builder` to all 5 API DTO records (IndexerStatusResponse, TransferEvent, WalletAddressRequest, WalletAddressResponse, ErrorResponse)
- Replace explicit constructor with `@RequiredArgsConstructor` in `ApiKeyAuthFilter`
- Use static imports for enum constants (`EVM`, `SOLANA`, `POLYGON`, `ETHEREUM`, etc.) across 6 test files
- Eliminate FQDN inline usage (`com.stablebridge.indexer.api.NetworkType.EVM`) in `WalletControllerTest`
- Use `var` for local variables where type is obvious in `WalletAddressPersistenceAdapterTest`, `KafkaTransferEventPublisherTest`, `RedisBlockProgressStoreTest`
- Inject `ObjectMapper` via `@Autowired` in `StatusControllerTest` (was manually created with old `com.fasterxml.jackson` namespace)
- Remove excessive javadocs from self-explanatory `GuavaBloomAutoConfiguration` and `RedisBloomAutoConfiguration`

## Test plan

- [x] `./gradlew build` passes (compile + Spotless + all tests green)
- [x] No behavioral changes — all fixes are style/convention enforcement only
- [x] Pre-commit Spotless check passes
- [x] Pre-push unit + integration tests pass

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)