### PR TITLE
SBI-18: EVM RPC resilience — circuit breaker, retry, rate limiter

### DIFF
--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmRpcResilienceException.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmRpcResilienceException.java
@@ -1,0 +1,27 @@
+package com.stablebridge.indexer.infrastructure.chain.evm;
+
+class EvmRpcResilienceException extends RuntimeException {
+
+    private EvmRpcResilienceException(String message) {
+        super(message);
+    }
+
+    private EvmRpcResilienceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    static EvmRpcResilienceException circuitBreakerOpen(String chainName) {
+        return new EvmRpcResilienceException(
+                "Circuit breaker is OPEN for chain=%s — all RPC endpoints unavailable".formatted(chainName));
+    }
+
+    static EvmRpcResilienceException rateLimited(String chainName) {
+        return new EvmRpcResilienceException(
+                "Rate limiter rejected call for chain=%s — too many requests".formatted(chainName));
+    }
+
+    static EvmRpcResilienceException retryExhausted(String chainName, Throwable cause) {
+        return new EvmRpcResilienceException(
+                "All retry attempts exhausted for chain=%s".formatted(chainName), cause);
+    }
+}

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/evm/ResilientEvmRpcClient.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/evm/ResilientEvmRpcClient.java
@@ -1,0 +1,128 @@
+package com.stablebridge.indexer.infrastructure.chain.evm;
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.core.IntervalFunction;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.OPEN;
+
+@Slf4j
+class ResilientEvmRpcClient {
+
+    private static final int SLIDING_WINDOW_SIZE = 10;
+    private static final int FAILURE_RATE_THRESHOLD = 50;
+    private static final Duration WAIT_DURATION_IN_OPEN_STATE = Duration.ofSeconds(30);
+    private static final int PERMITTED_CALLS_IN_HALF_OPEN = 3;
+    private static final Duration RETRY_WAIT_DURATION = Duration.ofSeconds(1);
+    private static final double RETRY_EXPONENTIAL_BACKOFF_MULTIPLIER = 2.0;
+    private static final Duration RATE_LIMITER_TIMEOUT = Duration.ofSeconds(5);
+
+    private final EvmRpcClient delegate;
+    private final String chainName;
+    private final CircuitBreaker circuitBreaker;
+    private final Retry retry;
+    private final RateLimiter rateLimiter;
+
+    ResilientEvmRpcClient(EvmRpcClient delegate, String chainName, int maxRetries,
+                          int rateLimitRps, int rateLimitBurst) {
+        this.delegate = delegate;
+        this.chainName = chainName;
+        this.circuitBreaker = createCircuitBreaker(chainName);
+        this.retry = createRetry(chainName, maxRetries);
+        this.rateLimiter = createRateLimiter(chainName, rateLimitRps, rateLimitBurst);
+    }
+
+    long getLatestBlockNumber() {
+        return executeWithResilience(() -> delegate.getLatestBlockNumber(), "getLatestBlockNumber");
+    }
+
+    EvmBlock getBlockByNumber(long blockNumber) {
+        return executeWithResilience(() -> delegate.getBlockByNumber(blockNumber), "getBlockByNumber");
+    }
+
+    List<EvmReceipt> getTransactionReceipts(List<String> txHashes) {
+        return executeWithResilience(() -> delegate.getTransactionReceipts(txHashes), "getTransactionReceipts");
+    }
+
+    List<EvmReceipt> getBlockReceipts(long blockNumber) {
+        return executeWithResilience(() -> delegate.getBlockReceipts(blockNumber), "getBlockReceipts");
+    }
+
+    boolean supportsBlockReceipts() {
+        return delegate.supportsBlockReceipts();
+    }
+
+    boolean isCircuitBreakerOpen() {
+        return circuitBreaker.getState() == OPEN;
+    }
+
+    CircuitBreaker getCircuitBreaker() {
+        return circuitBreaker;
+    }
+
+    RateLimiter getRateLimiter() {
+        return rateLimiter;
+    }
+
+    private <T> T executeWithResilience(Supplier<T> supplier, String methodName) {
+        var decorated = decorateSupplier(supplier);
+        try {
+            return decorated.get();
+        } catch (CallNotPermittedException e) {
+            log.warn("Circuit breaker OPEN for chain={}, method={}", chainName, methodName);
+            throw EvmRpcResilienceException.circuitBreakerOpen(chainName);
+        } catch (RequestNotPermitted e) {
+            log.warn("Rate limiter rejected call for chain={}, method={}", chainName, methodName);
+            throw EvmRpcResilienceException.rateLimited(chainName);
+        }
+    }
+
+    private <T> Supplier<T> decorateSupplier(Supplier<T> supplier) {
+        var decorated = CircuitBreaker.decorateSupplier(circuitBreaker, supplier);
+        decorated = Retry.decorateSupplier(retry, decorated);
+        return RateLimiter.decorateSupplier(rateLimiter, decorated);
+    }
+
+    private static CircuitBreaker createCircuitBreaker(String chainName) {
+        var config = CircuitBreakerConfig.custom()
+                .slidingWindowSize(SLIDING_WINDOW_SIZE)
+                .failureRateThreshold(FAILURE_RATE_THRESHOLD)
+                .waitDurationInOpenState(WAIT_DURATION_IN_OPEN_STATE)
+                .permittedNumberOfCallsInHalfOpenState(PERMITTED_CALLS_IN_HALF_OPEN)
+                .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+                .recordExceptions(EvmRpcException.class)
+                .build();
+        return CircuitBreaker.of("evm-rpc-%s".formatted(chainName), config);
+    }
+
+    private static Retry createRetry(String chainName, int maxRetries) {
+        var config = RetryConfig.custom()
+                .maxAttempts(maxRetries)
+                .intervalFunction(IntervalFunction.ofExponentialBackoff(
+                        RETRY_WAIT_DURATION, RETRY_EXPONENTIAL_BACKOFF_MULTIPLIER))
+                .retryExceptions(EvmRpcException.class)
+                .ignoreExceptions(EvmRpcResilienceException.class)
+                .build();
+        return Retry.of("evm-rpc-%s".formatted(chainName), config);
+    }
+
+    private static RateLimiter createRateLimiter(String chainName, int rateLimitRps, int rateLimitBurst) {
+        var config = RateLimiterConfig.custom()
+                .limitForPeriod(rateLimitRps)
+                .limitRefreshPeriod(Duration.ofSeconds(1))
+                .timeoutDuration(RATE_LIMITER_TIMEOUT)
+                .build();
+        return RateLimiter.of("evm-rpc-%s".formatted(chainName), config);
+    }
+}

--- a/stablebridge-indexer/src/main/resources/application.yml
+++ b/stablebridge-indexer/src/main/resources/application.yml
@@ -46,6 +46,32 @@ management:
       show-details: always
 
 # ---------------------------------------------------------------------------
+# Resilience4j defaults (programmatic config per chain overrides these)
+# ---------------------------------------------------------------------------
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        sliding-window-size: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+        permitted-number-of-calls-in-half-open-state: 3
+        sliding-window-type: COUNT_BASED
+        register-health-indicator: true
+  retry:
+    configs:
+      default:
+        max-attempts: 3
+        wait-duration: 1s
+        exponential-backoff-multiplier: 2
+  ratelimiter:
+    configs:
+      default:
+        limit-for-period: 25
+        limit-refresh-period: 1s
+        timeout-duration: 5s
+
+# ---------------------------------------------------------------------------
 # Indexer configuration
 # ---------------------------------------------------------------------------
 indexer:

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/evm/ResilientEvmRpcClientTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/evm/ResilientEvmRpcClientTest.java
@@ -1,0 +1,327 @@
+package com.stablebridge.indexer.infrastructure.chain.evm;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ResilientEvmRpcClient")
+class ResilientEvmRpcClientTest {
+
+    private static final String CHAIN_NAME = "ethereum_mainnet";
+    private static final int MAX_RETRIES = 3;
+    private static final int RATE_LIMIT_RPS = 50;
+    private static final int RATE_LIMIT_BURST = 100;
+    private static final long BLOCK_NUMBER = 1_000_000L;
+    private static final String TX_HASH = "0xtx_hash_1";
+
+    @Mock
+    private EvmRpcClient delegate;
+
+    private ResilientEvmRpcClient resilientClient;
+
+    @BeforeEach
+    void setUp() {
+        resilientClient = new ResilientEvmRpcClient(
+                delegate, CHAIN_NAME, MAX_RETRIES, RATE_LIMIT_RPS, RATE_LIMIT_BURST);
+    }
+
+    @Nested
+    @DisplayName("delegation")
+    class Delegation {
+
+        @Test
+        @DisplayName("delegates getLatestBlockNumber to underlying client")
+        void delegatesGetLatestBlockNumber() {
+            // given
+            given(delegate.getLatestBlockNumber()).willReturn(BLOCK_NUMBER);
+
+            // when
+            var result = resilientClient.getLatestBlockNumber();
+
+            // then
+            assertThat(result).isEqualTo(BLOCK_NUMBER);
+            then(delegate).should().getLatestBlockNumber();
+        }
+
+        @Test
+        @DisplayName("delegates getBlockByNumber to underlying client")
+        void delegatesGetBlockByNumber() {
+            // given
+            var expectedBlock = EvmBlock.builder()
+                    .number("0xf4240")
+                    .hash("0xblock_hash")
+                    .parentHash("0xparent_hash")
+                    .timestamp("0x65b3e8c0")
+                    .transactions(List.of())
+                    .build();
+            given(delegate.getBlockByNumber(BLOCK_NUMBER)).willReturn(expectedBlock);
+
+            // when
+            var result = resilientClient.getBlockByNumber(BLOCK_NUMBER);
+
+            // then
+            assertThat(result).usingRecursiveComparison().isEqualTo(expectedBlock);
+        }
+
+        @Test
+        @DisplayName("delegates getTransactionReceipts to underlying client")
+        void delegatesGetTransactionReceipts() {
+            // given
+            var txHashes = List.of(TX_HASH);
+            var expectedReceipts = List.of(EvmReceipt.builder()
+                    .transactionHash(TX_HASH)
+                    .transactionIndex("0x0")
+                    .blockNumber("0xf4240")
+                    .blockHash("0xblock_hash")
+                    .from("0xsender")
+                    .to("0xreceiver")
+                    .status("0x1")
+                    .logs(List.of())
+                    .build());
+            given(delegate.getTransactionReceipts(txHashes)).willReturn(expectedReceipts);
+
+            // when
+            var result = resilientClient.getTransactionReceipts(txHashes);
+
+            // then
+            assertThat(result).usingRecursiveComparison().isEqualTo(expectedReceipts);
+        }
+
+        @Test
+        @DisplayName("delegates getBlockReceipts to underlying client")
+        void delegatesGetBlockReceipts() {
+            // given
+            var expectedReceipts = List.of(EvmReceipt.builder()
+                    .transactionHash(TX_HASH)
+                    .transactionIndex("0x0")
+                    .blockNumber("0xf4240")
+                    .blockHash("0xblock_hash")
+                    .from("0xsender")
+                    .to("0xreceiver")
+                    .status("0x1")
+                    .logs(List.of())
+                    .build());
+            given(delegate.getBlockReceipts(BLOCK_NUMBER)).willReturn(expectedReceipts);
+
+            // when
+            var result = resilientClient.getBlockReceipts(BLOCK_NUMBER);
+
+            // then
+            assertThat(result).usingRecursiveComparison().isEqualTo(expectedReceipts);
+        }
+
+        @Test
+        @DisplayName("delegates supportsBlockReceipts to underlying client without resilience wrapping")
+        void delegatesSupportsBlockReceipts() {
+            // given
+            given(delegate.supportsBlockReceipts()).willReturn(true);
+
+            // when
+            var result = resilientClient.supportsBlockReceipts();
+
+            // then
+            assertThat(result).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("circuit breaker")
+    class CircuitBreakerTests {
+
+        @Test
+        @DisplayName("circuit breaker is CLOSED initially")
+        void circuitBreakerIsClosedInitially() {
+            // given — fresh client
+
+            // when
+            var isOpen = resilientClient.isCircuitBreakerOpen();
+
+            // then
+            assertThat(isOpen).isFalse();
+        }
+
+        @Test
+        @DisplayName("circuit breaker opens after failure threshold is reached")
+        void circuitBreakerOpensAfterFailureThreshold() {
+            // given
+            given(delegate.getLatestBlockNumber())
+                    .willThrow(EvmRpcException.networkError("eth_blockNumber",
+                            new RuntimeException("connection refused")));
+
+            // when — exhaust sliding window (10 calls) to trigger the 50% failure threshold
+            IntStream.range(0, 10).forEach(i -> {
+                try {
+                    resilientClient.getLatestBlockNumber();
+                } catch (Exception ignored) {
+                    // expected failures
+                }
+            });
+
+            // then
+            assertThat(resilientClient.isCircuitBreakerOpen()).isTrue();
+        }
+
+        @Test
+        @DisplayName("throws EvmRpcResilienceException when circuit breaker is OPEN")
+        void throwsResilienceExceptionWhenCircuitBreakerOpen() {
+            // given — force circuit breaker to OPEN state
+            resilientClient.getCircuitBreaker().transitionToOpenState();
+
+            // when / then
+            assertThatThrownBy(() -> resilientClient.getLatestBlockNumber())
+                    .isInstanceOf(EvmRpcResilienceException.class)
+                    .hasMessageContaining("Circuit breaker is OPEN")
+                    .hasMessageContaining(CHAIN_NAME);
+        }
+
+        @Test
+        @DisplayName("circuit breaker records successful calls and stays CLOSED")
+        void circuitBreakerStaysClosedOnSuccess() {
+            // given
+            given(delegate.getLatestBlockNumber()).willReturn(BLOCK_NUMBER);
+
+            // when
+            IntStream.range(0, 10).forEach(i -> resilientClient.getLatestBlockNumber());
+
+            // then
+            assertThat(resilientClient.isCircuitBreakerOpen()).isFalse();
+        }
+
+        @Test
+        @DisplayName("circuit breaker state transitions from OPEN to HALF_OPEN are exposed")
+        void circuitBreakerStateIsAccessible() {
+            // given
+            resilientClient.getCircuitBreaker().transitionToOpenState();
+
+            // when
+            resilientClient.getCircuitBreaker().transitionToHalfOpenState();
+
+            // then
+            assertThat(resilientClient.getCircuitBreaker().getState())
+                    .isEqualTo(CircuitBreaker.State.HALF_OPEN);
+        }
+    }
+
+    @Nested
+    @DisplayName("retry")
+    class RetryTests {
+
+        @Test
+        @DisplayName("retries on EvmRpcException and succeeds on later attempt")
+        void retriesAndSucceeds() {
+            // given
+            given(delegate.getLatestBlockNumber())
+                    .willThrow(EvmRpcException.networkError("eth_blockNumber",
+                            new RuntimeException("timeout")))
+                    .willReturn(BLOCK_NUMBER);
+
+            // when
+            var result = resilientClient.getLatestBlockNumber();
+
+            // then
+            assertThat(result).isEqualTo(BLOCK_NUMBER);
+            then(delegate).should(times(2)).getLatestBlockNumber();
+        }
+
+        @Test
+        @DisplayName("throws after all retry attempts are exhausted")
+        void throwsAfterRetryExhaustion() {
+            // given
+            given(delegate.getLatestBlockNumber())
+                    .willThrow(EvmRpcException.networkError("eth_blockNumber",
+                            new RuntimeException("connection refused")));
+
+            // when / then
+            assertThatThrownBy(() -> resilientClient.getLatestBlockNumber())
+                    .isInstanceOf(EvmRpcException.class)
+                    .hasMessageContaining("connection refused");
+            then(delegate).should(times(MAX_RETRIES)).getLatestBlockNumber();
+        }
+    }
+
+    @Nested
+    @DisplayName("rate limiter")
+    class RateLimiterTests {
+
+        @Test
+        @DisplayName("allows calls within rate limit")
+        void allowsCallsWithinRateLimit() {
+            // given
+            given(delegate.getLatestBlockNumber()).willReturn(BLOCK_NUMBER);
+
+            // when
+            var result = resilientClient.getLatestBlockNumber();
+
+            // then
+            assertThat(result).isEqualTo(BLOCK_NUMBER);
+        }
+
+        @Test
+        @DisplayName("throws EvmRpcResilienceException when rate limit is exhausted")
+        void throwsResilienceExceptionWhenRateLimited() {
+            // given — drain all permits and set timeout to zero to force immediate rejection
+            resilientClient.getRateLimiter().drainPermissions();
+            resilientClient.getRateLimiter().changeTimeoutDuration(Duration.ZERO);
+
+            // when / then
+            assertThatThrownBy(() -> resilientClient.getLatestBlockNumber())
+                    .isInstanceOf(EvmRpcResilienceException.class)
+                    .hasMessageContaining("Rate limiter rejected call")
+                    .hasMessageContaining(CHAIN_NAME);
+        }
+    }
+
+    @Nested
+    @DisplayName("combined resilience")
+    class CombinedResilienceTests {
+
+        @Test
+        @DisplayName("retry works with circuit breaker — retries before circuit opens")
+        void retryWorksWithCircuitBreaker() {
+            // given
+            given(delegate.getLatestBlockNumber())
+                    .willThrow(EvmRpcException.networkError("eth_blockNumber",
+                            new RuntimeException("transient error")))
+                    .willThrow(EvmRpcException.networkError("eth_blockNumber",
+                            new RuntimeException("transient error")))
+                    .willReturn(BLOCK_NUMBER);
+
+            // when
+            var result = resilientClient.getLatestBlockNumber();
+
+            // then
+            assertThat(result).isEqualTo(BLOCK_NUMBER);
+            then(delegate).should(times(3)).getLatestBlockNumber();
+            assertThat(resilientClient.isCircuitBreakerOpen()).isFalse();
+        }
+
+        @Test
+        @DisplayName("does not retry EvmRpcResilienceException")
+        void doesNotRetryResilienceException() {
+            // given — force circuit breaker to OPEN
+            resilientClient.getCircuitBreaker().transitionToOpenState();
+
+            // when / then — should throw immediately without retries
+            assertThatThrownBy(() -> resilientClient.getLatestBlockNumber())
+                    .isInstanceOf(EvmRpcResilienceException.class)
+                    .hasMessageContaining("Circuit breaker is OPEN");
+            then(delegate).shouldHaveNoInteractions();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ResilientEvmRpcClient` that wraps `EvmRpcClient` with Resilience4j programmatic circuit breaker, retry (exponential backoff), and rate limiter — all dynamically named per chain
- Add `EvmRpcResilienceException` with static factory methods (`circuitBreakerOpen`, `rateLimited`, `retryExhausted`) to signal PARKED state to the worker engine
- Add default Resilience4j YAML configuration in `application.yml`

## Implementation Details
- **Programmatic API** (not annotations) — avoids Spring proxy complexity while supporting dynamic per-chain instance names
- **Decoration order**: CircuitBreaker → Retry → RateLimiter — circuit breaker is innermost (closest to the actual call), retry wraps it, rate limiter is outermost
- **Circuit breaker**: COUNT_BASED sliding window (10 calls), 50% failure threshold, 30s wait in OPEN state, records `EvmRpcException` only
- **Retry**: Exponential backoff (1s base, 2x multiplier), retries `EvmRpcException`, ignores `EvmRpcResilienceException`
- **Rate limiter**: Configurable RPS from `RpcProperties`, 5s timeout before rejection
- All classes are package-private in the infrastructure ACL layer

## Test plan
- [x] Delegation tests — all 5 `EvmRpcClient` methods are correctly delegated
- [x] Circuit breaker CLOSED initially
- [x] Circuit breaker opens after failure threshold (10 failures at 50% rate)
- [x] `EvmRpcResilienceException.circuitBreakerOpen()` thrown when CB is OPEN
- [x] Circuit breaker stays CLOSED on successful calls
- [x] Circuit breaker state transitions (OPEN → HALF_OPEN) are accessible
- [x] Retry succeeds on later attempt after transient failure
- [x] Throws after all retry attempts exhausted (3 attempts)
- [x] Rate limiter allows calls within limit
- [x] `EvmRpcResilienceException.rateLimited()` thrown when rate limit exhausted
- [x] Combined: retry + circuit breaker work together
- [x] Combined: `EvmRpcResilienceException` is NOT retried
- [x] `./gradlew build` passes (compile + Spotless + all tests)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)