### PR TITLE
SBI-25: Add EVM end-to-end test for block-to-transfer pipeline

### DIFF
--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmChainIndexerE2eTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmChainIndexerE2eTest.java
@@ -36,9 +36,9 @@ class EvmChainIndexerE2eTest {
     private static final long BLOCK_NUMBER = 19_500_032L;
     private static final String BLOCK_NUMBER_HEX = "0x1298c00";
     private static final String BLOCK_HASH =
-            "0xblockhash1234567890abcdef1234567890abcdef1234567890abcdef12345678";
+            "0xb10c4a541234567890abcdef1234567890abcdef1234567890abcdef12345678";
     private static final String PARENT_HASH =
-            "0xparenthash234567890abcdef1234567890abcdef1234567890abcdef12345678";
+            "0xpa4e274a5234567890abcdef1234567890abcdef1234567890abcdef12345678";
     private static final String BLOCK_TIMESTAMP_HEX = "0x65b3e8c0";
     private static final Instant BLOCK_TIMESTAMP = HexUtils.hexToInstant(BLOCK_TIMESTAMP_HEX);
 
@@ -58,12 +58,12 @@ class EvmChainIndexerE2eTest {
             "0x00000000000000000000000000000000000000000000000000000000000f4240";
     private static final String USDC_RAW_AMOUNT = "1000000";
 
-    private static final String TX_HASH_USDC = "0xtx_usdc_abc123def456789012345678901234567890abcdef1234567890ab";
-    private static final String TX_HASH_UNKNOWN = "0xtx_unknown_def456789012345678901234567890abcdef1234567890abcd";
+    private static final String TX_HASH_USDC = "0xabc123def456789012345678901234567890abcdef1234567890abcdef123456";
+    private static final String TX_HASH_UNKNOWN = "0xdef456789012345678901234567890abcdef1234567890abcdef1234567890ab";
 
-    private static final String ETH_SENDER = "0xethsender890abcdef1234567890abcdef12345678";
-    private static final String ETH_RECEIVER = "0xethreceiver0abcdef1234567890abcdef12345678";
-    private static final String TX_HASH_ETH = "0xtx_eth_789012345678901234567890abcdef1234567890abcdef12345678";
+    private static final String ETH_SENDER = "0xe74534de890abcdef1234567890abcdef12345678";
+    private static final String ETH_RECEIVER = "0xe74ece14e0abcdef1234567890abcdef12345678";
+    private static final String TX_HASH_ETH = "0xe74789012345678901234567890abcdef1234567890abcdef1234567890abcd";
 
     private EvmChainIndexer indexer;
     private EvmChainIndexer indexerWithNativeTransfers;


### PR DESCRIPTION
## Summary
- WireMock-based E2E test that wires together real EVM components (EvmRpcClient, ResilientEvmRpcClient, EvmErc20TransferParser, EvmNativeTransferParser, EvmChainIndexer) to verify the full indexing pipeline
- Tests block fetch -> receipt fetch -> transfer parsing -> whitelist filtering with no mocks
- Verifies that only whitelisted tokens (USDC) produce Transfer domain objects while unknown tokens are silently skipped

## Test scenarios
- **USDC + unknown token block**: block with 2 transactions (USDC transfer + unknown token), verifies only 1 USDC Transfer returned with correct rawAmount, amount, decimals, tokenSymbol, addresses
- **Native + ERC-20 transfers**: block with ETH native transfer + USDC, verifies both transfers returned when native indexing enabled
- **Empty block**: verifies zero transfers returned for block with no transactions
- **getLatestFinalizedBlockNumber**: verifies hex-to-long RPC response conversion

## Test plan
- [x] All 4 E2E test scenarios pass
- [x] Single-assert pattern with `usingRecursiveComparison().withComparatorForType(BigDecimal::compareTo, BigDecimal.class)`
- [x] WireMock scenarios used for sequential HTTP request/response stubbing
- [x] `./gradlew build` passes (compile + Spotless + all tests)
- [x] No mocks — real component wiring validates integration correctness

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test coverage for EVM chain indexing functionality. Test scenarios validate correct handling of ERC-20 token transfer detection, native asset transfers, multiple token contracts, empty block processing, finalized block number resolution, and proper numeric field conversion to ensure reliable and accurate indexing operations across various blockchain network conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->