### PR TITLE
SBI-24: Add EVM chain factory with auto-configuration from properties

### DIFF
--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/application/config/ChainAutoConfiguration.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/application/config/ChainAutoConfiguration.java
@@ -5,9 +5,9 @@ import com.stablebridge.indexer.application.properties.ChainProperties;
 import com.stablebridge.indexer.application.properties.IndexerProperties;
 import com.stablebridge.indexer.application.properties.TokenContractProperties;
 import com.stablebridge.indexer.domain.port.ChainIndexer;
+import com.stablebridge.indexer.infrastructure.chain.evm.EvmChainConfig;
 import com.stablebridge.indexer.infrastructure.chain.evm.EvmChainIndexerFactory;
-import com.stablebridge.indexer.infrastructure.chain.evm.EvmChainIndexerFactory.EvmChainConfig;
-import com.stablebridge.indexer.infrastructure.chain.evm.EvmChainIndexerFactory.TokenConfig;
+import com.stablebridge.indexer.infrastructure.chain.evm.EvmChainTokenConfig;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -62,9 +62,9 @@ class ChainAutoConfiguration {
                 .build();
     }
 
-    private static List<TokenConfig> mapTokenContracts(List<TokenContractProperties> tokenContracts) {
+    private static List<EvmChainTokenConfig> mapTokenContracts(List<TokenContractProperties> tokenContracts) {
         return tokenContracts.stream()
-                .map(tc -> TokenConfig.builder()
+                .map(tc -> EvmChainTokenConfig.builder()
                         .address(tc.address())
                         .symbol(tc.symbol())
                         .decimals(tc.decimals())

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmChainConfig.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmChainConfig.java
@@ -1,0 +1,23 @@
+package com.stablebridge.indexer.infrastructure.chain.evm;
+
+import lombok.Builder;
+
+import java.time.Duration;
+import java.util.List;
+
+@Builder(toBuilder = true)
+public record EvmChainConfig(
+        String networkId,
+        String rpcUrl,
+        int rpcBatchSize,
+        boolean useBlockReceipts,
+        Duration rpcTimeout,
+        int maxRetries,
+        int rateLimitRps,
+        int rateLimitBurst,
+        boolean useFinalizedTag,
+        int minConfirmations,
+        boolean indexNativeTransfers,
+        int nativeDecimals,
+        List<EvmChainTokenConfig> tokenContracts
+) {}

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmChainIndexerFactory.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmChainIndexerFactory.java
@@ -3,11 +3,9 @@ package com.stablebridge.indexer.infrastructure.chain.evm;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stablebridge.indexer.domain.model.ChainId;
 import com.stablebridge.indexer.domain.port.ChainIndexer;
-import lombok.Builder;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -76,7 +74,7 @@ public class EvmChainIndexerFactory {
         return chainId;
     }
 
-    private static List<EvmTokenConfig> mapTokenContracts(List<TokenConfig> tokenContracts) {
+    private static List<EvmTokenConfig> mapTokenContracts(List<EvmChainTokenConfig> tokenContracts) {
         return tokenContracts.stream()
                 .map(tc -> EvmTokenConfig.builder()
                         .address(tc.address())
@@ -86,27 +84,4 @@ public class EvmChainIndexerFactory {
                 .toList();
     }
 
-    @Builder(toBuilder = true)
-    public record EvmChainConfig(
-            String networkId,
-            String rpcUrl,
-            int rpcBatchSize,
-            boolean useBlockReceipts,
-            Duration rpcTimeout,
-            int maxRetries,
-            int rateLimitRps,
-            int rateLimitBurst,
-            boolean useFinalizedTag,
-            int minConfirmations,
-            boolean indexNativeTransfers,
-            int nativeDecimals,
-            List<TokenConfig> tokenContracts
-    ) {}
-
-    @Builder(toBuilder = true)
-    public record TokenConfig(
-            String address,
-            String symbol,
-            int decimals
-    ) {}
 }

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmChainTokenConfig.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmChainTokenConfig.java
@@ -1,0 +1,10 @@
+package com.stablebridge.indexer.infrastructure.chain.evm;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record EvmChainTokenConfig(
+        String address,
+        String symbol,
+        int decimals
+) {}

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/application/config/ChainAutoConfigurationTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/application/config/ChainAutoConfigurationTest.java
@@ -6,8 +6,8 @@ import com.stablebridge.indexer.application.properties.ConfirmationStrategy;
 import com.stablebridge.indexer.application.properties.IndexerProperties;
 import com.stablebridge.indexer.application.properties.RpcProperties;
 import com.stablebridge.indexer.application.properties.TokenContractProperties;
-import com.stablebridge.indexer.infrastructure.chain.evm.EvmChainIndexerFactory.EvmChainConfig;
-import com.stablebridge.indexer.infrastructure.chain.evm.EvmChainIndexerFactory.TokenConfig;
+import com.stablebridge.indexer.infrastructure.chain.evm.EvmChainConfig;
+import com.stablebridge.indexer.infrastructure.chain.evm.EvmChainTokenConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -124,7 +124,7 @@ class ChainAutoConfigurationTest {
                     .indexNativeTransfers(false)
                     .nativeDecimals(18)
                     .tokenContracts(List.of(
-                            TokenConfig.builder()
+                            EvmChainTokenConfig.builder()
                                     .address("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
                                     .symbol("USDC")
                                     .decimals(6)
@@ -160,7 +160,7 @@ class ChainAutoConfigurationTest {
                     .indexNativeTransfers(false)
                     .nativeDecimals(18)
                     .tokenContracts(List.of(
-                            TokenConfig.builder()
+                            EvmChainTokenConfig.builder()
                                     .address("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
                                     .symbol("USDC")
                                     .decimals(6)

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmChainIndexerFactoryTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmChainIndexerFactoryTest.java
@@ -1,8 +1,6 @@
 package com.stablebridge.indexer.infrastructure.chain.evm;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.stablebridge.indexer.infrastructure.chain.evm.EvmChainIndexerFactory.EvmChainConfig;
-import com.stablebridge.indexer.infrastructure.chain.evm.EvmChainIndexerFactory.TokenConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -69,11 +67,11 @@ class EvmChainIndexerFactoryTest {
         void createsChainIndexerWithMultipleTokenContracts() {
             // given
             var tokenContracts = List.of(
-                    TokenConfig.builder().address("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+                    EvmChainTokenConfig.builder().address("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
                             .symbol("USDC").decimals(6).build(),
-                    TokenConfig.builder().address("0xdAC17F958D2ee523a2206206994597C13D831ec7")
+                    EvmChainTokenConfig.builder().address("0xdAC17F958D2ee523a2206206994597C13D831ec7")
                             .symbol("USDT").decimals(6).build(),
-                    TokenConfig.builder().address("0x6B175474E89094C44Da98b954EedeAC495271d0F")
+                    EvmChainTokenConfig.builder().address("0x6B175474E89094C44Da98b954EedeAC495271d0F")
                             .symbol("DAI").decimals(18).build()
             );
             var config = anEvmChainConfigWithTokens("ethereum_mainnet", tokenContracts);
@@ -132,7 +130,7 @@ class EvmChainIndexerFactoryTest {
                 .indexNativeTransfers(false)
                 .nativeDecimals(18)
                 .tokenContracts(List.of(
-                        TokenConfig.builder()
+                        EvmChainTokenConfig.builder()
                                 .address("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
                                 .symbol("USDC")
                                 .decimals(6)
@@ -141,7 +139,7 @@ class EvmChainIndexerFactoryTest {
     }
 
     private static EvmChainConfig anEvmChainConfigWithTokens(String networkId,
-                                                               List<TokenConfig> tokenContracts) {
+                                                               List<EvmChainTokenConfig> tokenContracts) {
         return EvmChainConfig.builder()
                 .networkId(networkId)
                 .rpcUrl("https://rpc.example.com/v2/demo")


### PR DESCRIPTION
## Summary
- Add `EvmChainIndexerFactory` in `infrastructure.chain.evm` that creates fully wired `EvmChainIndexer` instances from a simple `EvmChainConfig` record, keeping all package-private EVM classes properly encapsulated
- Add `ChainAutoConfiguration` in `application.config` that reads `IndexerProperties`, maps `ChainProperties` to `EvmChainConfig` (respecting ArchUnit infrastructure-must-not-depend-on-application boundary), and registers enabled EVM chains as a `List<ChainIndexer>` bean
- Disabled chains and non-EVM chain types are filtered out; the factory maps networkId strings (e.g., `ethereum_mainnet`) to `ChainId` enum values

## Design Decisions
- Introduced `EvmChainConfig` and `TokenConfig` records inside `EvmChainIndexerFactory` as the ACL boundary — infrastructure accepts these pure data records instead of application-layer `ChainProperties`, satisfying the ArchUnit rule that infrastructure must not depend on application
- The `ChainAutoConfiguration` handles the mapping from `ChainProperties` → `EvmChainConfig`, keeping the application layer as the thin orchestration shell
- `EvmChainIndexerFactory` is the single **public** entry point from the otherwise package-private EVM infrastructure layer

## Test plan
- [x] `EvmChainIndexerFactoryTest`: verifies correct ChainId resolution for ethereum/polygon/base, multi-token support, and unknown networkId error handling
- [x] `ChainAutoConfigurationTest`: verifies 3-chain scenario (2 enabled EVM + 1 disabled = 2 indexers), non-EVM type skipping, empty configs, and correct `ChainProperties` → `EvmChainConfig` mapping
- [x] All ArchUnit rules pass (including infrastructure-must-not-depend-on-application)
- [x] `./gradlew build` passes (compile + Spotless + all tests)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic configuration support for multiple EVM-based blockchain networks (Ethereum, Polygon, Base).
  * Enabled flexible indexing of native transfers and token contracts across configured chains.
  * Introduced configurable confirmation strategies and RPC parameters per network.

* **Tests**
  * Added comprehensive test coverage for chain indexer configuration and factory creation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->