### PR TITLE
SBI-28: Add CatchupWorker for backfilling historical block gaps

### DIFF
--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/domain/port/BlockProgressStore.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/domain/port/BlockProgressStore.java
@@ -2,6 +2,7 @@ package com.stablebridge.indexer.domain.port;
 
 import com.stablebridge.indexer.domain.model.ChainId;
 
+import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Set;
 
@@ -59,4 +60,29 @@ public interface BlockProgressStore {
      * @param blockNumber the block number to remove from the failed set
      */
     void removeFailedBlock(ChainId chainId, long blockNumber);
+
+    /**
+     * Saves a catchup range for the given chain, indicating a gap that needs backfilling.
+     *
+     * @param chainId   the chain to update
+     * @param fromBlock the start block of the catchup range (inclusive)
+     * @param toBlock   the end block of the catchup range (inclusive)
+     */
+    void saveCatchupRange(ChainId chainId, long fromBlock, long toBlock);
+
+    /**
+     * Returns all catchup ranges for the given chain, mapping start block to end block.
+     *
+     * @param chainId the chain to query
+     * @return a map of fromBlock to toBlock for all pending catchup ranges (may be empty)
+     */
+    Map<Long, Long> getCatchupRanges(ChainId chainId);
+
+    /**
+     * Removes a catchup range after it has been fully processed.
+     *
+     * @param chainId   the chain to update
+     * @param fromBlock the start block of the catchup range to remove
+     */
+    void removeCatchupRange(ChainId chainId, long fromBlock);
 }

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/domain/service/CatchupWorker.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/domain/service/CatchupWorker.java
@@ -1,0 +1,101 @@
+package com.stablebridge.indexer.domain.service;
+
+import com.stablebridge.indexer.domain.model.WorkerType;
+import com.stablebridge.indexer.domain.port.AddressFilter;
+import com.stablebridge.indexer.domain.port.BlockProgressStore;
+import com.stablebridge.indexer.domain.port.ChainIndexer;
+import com.stablebridge.indexer.domain.port.TransferEventPublisher;
+import com.stablebridge.indexer.domain.port.WalletAddressRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.LongStream;
+
+import static com.stablebridge.indexer.domain.model.WorkerType.CATCHUP;
+
+@Slf4j
+public class CatchupWorker extends BaseWorker {
+
+    private final int chunkSize;
+
+    protected CatchupWorker(
+            ChainIndexer chainIndexer,
+            AddressFilter addressFilter,
+            TransferEventPublisher transferEventPublisher,
+            BlockProgressStore blockProgressStore,
+            WalletAddressRepository walletAddressRepository,
+            MeterRegistry meterRegistry,
+            int chunkSize) {
+        super(chainIndexer, addressFilter, transferEventPublisher,
+                blockProgressStore, walletAddressRepository, meterRegistry);
+        this.chunkSize = chunkSize;
+    }
+
+    @Override
+    public WorkerType getWorkerType() {
+        return CATCHUP;
+    }
+
+    public void processRanges() {
+        var ranges = getBlockProgressStore().getCatchupRanges(getChainId());
+
+        if (ranges.isEmpty()) {
+            log.debug("No catchup ranges found — chain={}", getChainId());
+            return;
+        }
+
+        log.info("Processing {} catchup range(s) — chain={}", ranges.size(), getChainId());
+
+        ranges.forEach((fromBlock, toBlock) -> {
+            processRange(fromBlock, toBlock);
+            getBlockProgressStore().removeCatchupRange(getChainId(), fromBlock);
+        });
+    }
+
+    public int getChunkSize() {
+        return chunkSize;
+    }
+
+    private void processRange(long fromBlock, long toBlock) {
+        log.info("Processing catchup range — chain={}, fromBlock={}, toBlock={}", getChainId(), fromBlock, toBlock);
+
+        var chunkStarts = LongStream.iterate(fromBlock, b -> b <= toBlock, b -> b + chunkSize)
+                .boxed()
+                .toList();
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = chunkStarts.stream()
+                    .map(chunkStart -> {
+                        var chunkEnd = Math.min(chunkStart + chunkSize - 1, toBlock);
+                        return executor.submit(() -> processChunk(chunkStart, chunkEnd));
+                    })
+                    .toList();
+
+            for (Future<?> future : futures) {
+                try {
+                    future.get();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    log.error("Catchup range processing interrupted — chain={}", getChainId(), e);
+                    return;
+                } catch (ExecutionException e) {
+                    log.error("Catchup chunk failed — chain={}", getChainId(), e);
+                }
+            }
+        }
+    }
+
+    private void processChunk(long fromBlock, long toBlock) {
+        LongStream.rangeClosed(fromBlock, toBlock).forEach(block -> {
+            try {
+                processBlock(block);
+            } catch (Exception e) {
+                log.error("Failed to process block during catchup — chain={}, block={}", getChainId(), block, e);
+                getBlockProgressStore().addFailedBlock(getChainId(), block);
+            }
+        });
+    }
+}

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/progress/RedisBlockProgressStore.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/progress/RedisBlockProgressStore.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -27,6 +28,7 @@ public class RedisBlockProgressStore implements BlockProgressStore {
 
     static final String PROGRESS_KEY = "indexer:progress";
     static final String FAILED_KEY_PREFIX = "indexer:failed:";
+    static final String CATCHUP_KEY_PREFIX = "indexer:catchup:";
 
     private final StringRedisTemplate redisTemplate;
 
@@ -65,7 +67,30 @@ public class RedisBlockProgressStore implements BlockProgressStore {
         redisTemplate.opsForZSet().remove(failedKey(chainId), String.valueOf(blockNumber));
     }
 
+    @Override
+    public void saveCatchupRange(ChainId chainId, long fromBlock, long toBlock) {
+        redisTemplate.opsForHash().put(catchupKey(chainId), String.valueOf(fromBlock), String.valueOf(toBlock));
+    }
+
+    @Override
+    public Map<Long, Long> getCatchupRanges(ChainId chainId) {
+        var entries = redisTemplate.opsForHash().entries(catchupKey(chainId));
+        return entries.entrySet().stream()
+                .collect(Collectors.toMap(
+                        e -> Long.parseLong(e.getKey().toString()),
+                        e -> Long.parseLong(e.getValue().toString())));
+    }
+
+    @Override
+    public void removeCatchupRange(ChainId chainId, long fromBlock) {
+        redisTemplate.opsForHash().delete(catchupKey(chainId), String.valueOf(fromBlock));
+    }
+
     private String failedKey(ChainId chainId) {
         return FAILED_KEY_PREFIX + chainId.name();
+    }
+
+    private String catchupKey(ChainId chainId) {
+        return CATCHUP_KEY_PREFIX + chainId.name();
     }
 }

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/domain/service/CatchupWorkerTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/domain/service/CatchupWorkerTest.java
@@ -1,0 +1,202 @@
+package com.stablebridge.indexer.domain.service;
+
+import com.stablebridge.indexer.domain.port.AddressFilter;
+import com.stablebridge.indexer.domain.port.BlockProgressStore;
+import com.stablebridge.indexer.domain.port.ChainIndexer;
+import com.stablebridge.indexer.domain.port.TransferEventPublisher;
+import com.stablebridge.indexer.domain.port.WalletAddressRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.stablebridge.indexer.domain.model.ChainId.ETHEREUM;
+import static com.stablebridge.indexer.domain.model.WorkerType.CATCHUP;
+import static com.stablebridge.indexer.testutil.TransferFixtures.aBlockResult;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CatchupWorker")
+class CatchupWorkerTest {
+
+    private static final int CHUNK_SIZE = 5;
+
+    @Mock
+    private ChainIndexer chainIndexer;
+
+    @Mock
+    private AddressFilter addressFilter;
+
+    @Mock
+    private TransferEventPublisher transferEventPublisher;
+
+    @Mock
+    private BlockProgressStore blockProgressStore;
+
+    @Mock
+    private WalletAddressRepository walletAddressRepository;
+
+    private MeterRegistry meterRegistry;
+
+    private CatchupWorker worker;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        given(chainIndexer.getChainId()).willReturn(ETHEREUM);
+        worker = new CatchupWorker(
+                chainIndexer, addressFilter, transferEventPublisher,
+                blockProgressStore, walletAddressRepository, meterRegistry,
+                CHUNK_SIZE);
+    }
+
+    @Nested
+    @DisplayName("processRanges")
+    class ProcessRanges {
+
+        @Test
+        @DisplayName("processes all blocks in a single range")
+        void processesAllBlocksInSingleRange() {
+            // given
+            given(blockProgressStore.getCatchupRanges(ETHEREUM))
+                    .willReturn(Map.of(100L, 104L));
+            var emptyBlockResult = aBlockResult().transfers(List.of()).build();
+            given(chainIndexer.indexBlock(100L)).willReturn(emptyBlockResult);
+            given(chainIndexer.indexBlock(101L)).willReturn(emptyBlockResult);
+            given(chainIndexer.indexBlock(102L)).willReturn(emptyBlockResult);
+            given(chainIndexer.indexBlock(103L)).willReturn(emptyBlockResult);
+            given(chainIndexer.indexBlock(104L)).willReturn(emptyBlockResult);
+
+            // when
+            worker.processRanges();
+
+            // then
+            then(chainIndexer).should().indexBlock(100L);
+            then(chainIndexer).should().indexBlock(101L);
+            then(chainIndexer).should().indexBlock(102L);
+            then(chainIndexer).should().indexBlock(103L);
+            then(chainIndexer).should().indexBlock(104L);
+        }
+
+        @Test
+        @DisplayName("processes multiple ranges")
+        void processesMultipleRanges() {
+            // given
+            given(blockProgressStore.getCatchupRanges(ETHEREUM))
+                    .willReturn(Map.of(100L, 102L, 200L, 201L));
+            var emptyBlockResult = aBlockResult().transfers(List.of()).build();
+            given(chainIndexer.indexBlock(100L)).willReturn(emptyBlockResult);
+            given(chainIndexer.indexBlock(101L)).willReturn(emptyBlockResult);
+            given(chainIndexer.indexBlock(102L)).willReturn(emptyBlockResult);
+            given(chainIndexer.indexBlock(200L)).willReturn(emptyBlockResult);
+            given(chainIndexer.indexBlock(201L)).willReturn(emptyBlockResult);
+
+            // when
+            worker.processRanges();
+
+            // then
+            then(chainIndexer).should().indexBlock(100L);
+            then(chainIndexer).should().indexBlock(101L);
+            then(chainIndexer).should().indexBlock(102L);
+            then(chainIndexer).should().indexBlock(200L);
+            then(chainIndexer).should().indexBlock(201L);
+        }
+
+        @Test
+        @DisplayName("does nothing when no ranges exist")
+        void doesNothingWhenNoRangesExist() {
+            // given
+            given(blockProgressStore.getCatchupRanges(ETHEREUM))
+                    .willReturn(Map.of());
+
+            // when
+            worker.processRanges();
+
+            // then
+            then(chainIndexer).should(never()).indexBlock(100L);
+        }
+
+        @Test
+        @DisplayName("removes range after processing")
+        void removesRangeAfterProcessing() {
+            // given
+            given(blockProgressStore.getCatchupRanges(ETHEREUM))
+                    .willReturn(Map.of(100L, 102L));
+            var emptyBlockResult = aBlockResult().transfers(List.of()).build();
+            given(chainIndexer.indexBlock(100L)).willReturn(emptyBlockResult);
+            given(chainIndexer.indexBlock(101L)).willReturn(emptyBlockResult);
+            given(chainIndexer.indexBlock(102L)).willReturn(emptyBlockResult);
+
+            // when
+            worker.processRanges();
+
+            // then
+            then(blockProgressStore).should().removeCatchupRange(ETHEREUM, 100L);
+        }
+
+        @Test
+        @DisplayName("adds failed block to failed set on error")
+        void addsFailedBlockToFailedSetOnError() {
+            // given
+            given(blockProgressStore.getCatchupRanges(ETHEREUM))
+                    .willReturn(Map.of(100L, 104L));
+            var emptyBlockResult = aBlockResult().transfers(List.of()).build();
+            given(chainIndexer.indexBlock(100L)).willReturn(emptyBlockResult);
+            given(chainIndexer.indexBlock(101L)).willReturn(emptyBlockResult);
+            given(chainIndexer.indexBlock(102L)).willThrow(new RuntimeException("RPC error"));
+            given(chainIndexer.indexBlock(103L)).willReturn(emptyBlockResult);
+            given(chainIndexer.indexBlock(104L)).willReturn(emptyBlockResult);
+
+            // when
+            worker.processRanges();
+
+            // then
+            then(blockProgressStore).should().addFailedBlock(ETHEREUM, 102L);
+        }
+    }
+
+    @Nested
+    @DisplayName("getWorkerType")
+    class GetWorkerType {
+
+        @Test
+        @DisplayName("returns CATCHUP")
+        void returnsCatchup() {
+            // given — worker created in setUp
+
+            // when
+            var workerType = worker.getWorkerType();
+
+            // then
+            assertThat(workerType).isEqualTo(CATCHUP);
+        }
+    }
+
+    @Nested
+    @DisplayName("configuration")
+    class Configuration {
+
+        @Test
+        @DisplayName("exposes chunk size")
+        void exposesChunkSize() {
+            // given — worker created in setUp
+
+            // when
+            var result = worker.getChunkSize();
+
+            // then
+            assertThat(result).isEqualTo(CHUNK_SIZE);
+        }
+    }
+}

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/progress/RedisBlockProgressStoreTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/progress/RedisBlockProgressStoreTest.java
@@ -11,6 +11,7 @@ import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 
+import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Set;
 
@@ -21,6 +22,7 @@ import static com.stablebridge.indexer.domain.model.ChainId.BSC;
 import static com.stablebridge.indexer.domain.model.ChainId.ETHEREUM;
 import static com.stablebridge.indexer.domain.model.ChainId.OPTIMISM;
 import static com.stablebridge.indexer.domain.model.ChainId.POLYGON;
+import static com.stablebridge.indexer.infrastructure.progress.RedisBlockProgressStore.CATCHUP_KEY_PREFIX;
 import static com.stablebridge.indexer.infrastructure.progress.RedisBlockProgressStore.FAILED_KEY_PREFIX;
 import static com.stablebridge.indexer.infrastructure.progress.RedisBlockProgressStore.PROGRESS_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -185,6 +187,84 @@ class RedisBlockProgressStoreTest {
             then(zSetOperations).should().remove(
                     FAILED_KEY_PREFIX + ETHEREUM.name(),
                     "42000"
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("saveCatchupRange")
+    class SaveCatchupRange {
+
+        @Test
+        @DisplayName("should save catchup range to Redis hash")
+        void shouldSaveCatchupRangeToRedisHash() {
+            // given
+            given(redisTemplate.opsForHash()).willReturn(hashOperations);
+
+            // when
+            store.saveCatchupRange(POLYGON, 1000L, 2000L);
+
+            // then
+            then(hashOperations).should().put(
+                    CATCHUP_KEY_PREFIX + POLYGON.name(),
+                    "1000",
+                    "2000"
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("getCatchupRanges")
+    class GetCatchupRanges {
+
+        @Test
+        @DisplayName("should return catchup ranges from Redis hash")
+        void shouldReturnCatchupRangesFromRedisHash() {
+            // given
+            given(redisTemplate.opsForHash()).willReturn(hashOperations);
+            given(hashOperations.entries(CATCHUP_KEY_PREFIX + ARBITRUM.name()))
+                    .willReturn(Map.of("500", "600", "700", "800"));
+
+            // when
+            var result = store.getCatchupRanges(ARBITRUM);
+
+            // then
+            assertThat(result).isEqualTo(Map.of(500L, 600L, 700L, 800L));
+        }
+
+        @Test
+        @DisplayName("should return empty map when no catchup ranges exist")
+        void shouldReturnEmptyMapWhenNoCatchupRangesExist() {
+            // given
+            given(redisTemplate.opsForHash()).willReturn(hashOperations);
+            given(hashOperations.entries(CATCHUP_KEY_PREFIX + BASE.name()))
+                    .willReturn(Map.of());
+
+            // when
+            var result = store.getCatchupRanges(BASE);
+
+            // then
+            assertThat(result).isEqualTo(Map.of());
+        }
+    }
+
+    @Nested
+    @DisplayName("removeCatchupRange")
+    class RemoveCatchupRange {
+
+        @Test
+        @DisplayName("should remove catchup range from Redis hash")
+        void shouldRemoveCatchupRangeFromRedisHash() {
+            // given
+            given(redisTemplate.opsForHash()).willReturn(hashOperations);
+
+            // when
+            store.removeCatchupRange(AVALANCHE, 3000L);
+
+            // then
+            then(hashOperations).should().delete(
+                    CATCHUP_KEY_PREFIX + AVALANCHE.name(),
+                    "3000"
             );
         }
     }


### PR DESCRIPTION
## Summary
- Add `CatchupWorker` extending `BaseWorker` that backfills historical block gaps using virtual threads for concurrent chunk processing
- Extend `BlockProgressStore` port with `saveCatchupRange`, `getCatchupRanges`, and `removeCatchupRange` methods
- Implement catchup range storage in `RedisBlockProgressStore` using Redis Hash (`indexer:catchup:<chainId>`)
- Full test coverage for both the worker and Redis store catchup operations

## Test plan
- [x] `CatchupWorkerTest` verifies single-range processing, multi-range processing, empty ranges, range removal after processing, and failed block tracking
- [x] `RedisBlockProgressStoreTest` verifies save, get, and remove catchup range operations
- [x] `./gradlew build` passes (compile + Spotless + all tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)