### PR TITLE
SBI-29: Add RescanWorker with exponential backoff retry

### DIFF
--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/domain/service/RescanWorker.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/domain/service/RescanWorker.java
@@ -1,0 +1,87 @@
+package com.stablebridge.indexer.domain.service;
+
+import com.stablebridge.indexer.domain.model.WorkerType;
+import com.stablebridge.indexer.domain.port.AddressFilter;
+import com.stablebridge.indexer.domain.port.BlockProgressStore;
+import com.stablebridge.indexer.domain.port.ChainIndexer;
+import com.stablebridge.indexer.domain.port.TransferEventPublisher;
+import com.stablebridge.indexer.domain.port.WalletAddressRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.stablebridge.indexer.domain.model.WorkerType.RESCAN;
+
+@Slf4j
+public class RescanWorker extends BaseWorker {
+
+    static final int MAX_ATTEMPTS = 5;
+
+    private final ConcurrentHashMap<Long, Integer> attemptCounts = new ConcurrentHashMap<>();
+
+    public RescanWorker(
+            ChainIndexer chainIndexer,
+            AddressFilter addressFilter,
+            TransferEventPublisher transferEventPublisher,
+            BlockProgressStore blockProgressStore,
+            WalletAddressRepository walletAddressRepository,
+            MeterRegistry meterRegistry) {
+        super(chainIndexer, addressFilter, transferEventPublisher,
+                blockProgressStore, walletAddressRepository, meterRegistry);
+    }
+
+    @Override
+    public WorkerType getWorkerType() {
+        return RESCAN;
+    }
+
+    public void rescan() {
+        var failedBlocks = getBlockProgressStore().getFailedBlocks(getChainId());
+
+        if (failedBlocks.isEmpty()) {
+            log.debug("No failed blocks to rescan — chain={}", getChainId());
+            return;
+        }
+
+        log.info("Rescanning {} failed blocks — chain={}", failedBlocks.size(), getChainId());
+
+        failedBlocks.stream()
+                .sorted()
+                .forEach(this::retryBlock);
+    }
+
+    private void retryBlock(long blockNumber) {
+        var attempt = attemptCounts.getOrDefault(blockNumber, 0) + 1;
+
+        if (attempt > MAX_ATTEMPTS) {
+            log.error("Max rescan attempts exceeded — chain={}, blockNumber={}, maxAttempts={}",
+                    getChainId(), blockNumber, MAX_ATTEMPTS);
+            attemptCounts.remove(blockNumber);
+            return;
+        }
+
+        var backoffMs = calculateBackoff(attempt);
+        log.info("Retrying failed block — attempt={}/{}, chain={}, blockNumber={}, backoffMs={}",
+                attempt, MAX_ATTEMPTS, getChainId(), blockNumber, backoffMs);
+
+        try {
+            Thread.sleep(backoffMs);
+            processBlock(blockNumber);
+            getBlockProgressStore().removeFailedBlock(getChainId(), blockNumber);
+            attemptCounts.remove(blockNumber);
+            log.info("Rescan succeeded — chain={}, blockNumber={}", getChainId(), blockNumber);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            attemptCounts.put(blockNumber, attempt);
+        } catch (Exception e) {
+            attemptCounts.put(blockNumber, attempt);
+            log.warn("Rescan failed — chain={}, blockNumber={}, attempt={}/{}, error={}",
+                    getChainId(), blockNumber, attempt, MAX_ATTEMPTS, e.getMessage());
+        }
+    }
+
+    long calculateBackoff(int attempt) {
+        return Math.min((long) Math.pow(2, attempt - 1) * 1000L, 30_000L);
+    }
+}

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/domain/service/RescanWorkerTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/domain/service/RescanWorkerTest.java
@@ -1,0 +1,208 @@
+package com.stablebridge.indexer.domain.service;
+
+import com.stablebridge.indexer.domain.port.AddressFilter;
+import com.stablebridge.indexer.domain.port.BlockProgressStore;
+import com.stablebridge.indexer.domain.port.ChainIndexer;
+import com.stablebridge.indexer.domain.port.TransferEventPublisher;
+import com.stablebridge.indexer.domain.port.WalletAddressRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.stablebridge.indexer.domain.model.ChainId.ETHEREUM;
+import static com.stablebridge.indexer.domain.model.WorkerType.RESCAN;
+import static com.stablebridge.indexer.domain.service.RescanWorker.MAX_ATTEMPTS;
+import static com.stablebridge.indexer.testutil.TransferFixtures.aBlockResult;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RescanWorker")
+class RescanWorkerTest {
+
+    @Mock
+    private ChainIndexer chainIndexer;
+
+    @Mock
+    private AddressFilter addressFilter;
+
+    @Mock
+    private TransferEventPublisher transferEventPublisher;
+
+    @Mock
+    private BlockProgressStore blockProgressStore;
+
+    @Mock
+    private WalletAddressRepository walletAddressRepository;
+
+    private MeterRegistry meterRegistry;
+
+    private RescanWorker worker;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        given(chainIndexer.getChainId()).willReturn(ETHEREUM);
+        worker = new RescanWorker(
+                chainIndexer, addressFilter, transferEventPublisher,
+                blockProgressStore, walletAddressRepository, meterRegistry);
+    }
+
+    @Nested
+    @DisplayName("rescan")
+    class Rescan {
+
+        @Test
+        @DisplayName("removes block from failed set on success")
+        void removesBlockFromFailedSetOnSuccess() {
+            // given
+            given(blockProgressStore.getFailedBlocks(ETHEREUM)).willReturn(Set.of(100L));
+            var blockResult = aBlockResult().transfers(List.of()).build();
+            given(chainIndexer.indexBlock(100L)).willReturn(blockResult);
+
+            // when
+            worker.rescan();
+
+            // then
+            then(blockProgressStore).should().removeFailedBlock(ETHEREUM, 100L);
+        }
+
+        @Test
+        @DisplayName("does nothing when no failed blocks")
+        void doesNothingWhenNoFailedBlocks() {
+            // given
+            given(blockProgressStore.getFailedBlocks(ETHEREUM)).willReturn(Set.of());
+
+            // when
+            worker.rescan();
+
+            // then
+            then(chainIndexer).should(never()).indexBlock(100L);
+        }
+
+        @Test
+        @DisplayName("increments attempt count on failure")
+        void incrementsAttemptCountOnFailure() {
+            // given
+            given(blockProgressStore.getFailedBlocks(ETHEREUM)).willReturn(Set.of(100L));
+            given(chainIndexer.indexBlock(100L)).willThrow(new RuntimeException("RPC error"));
+
+            // when
+            worker.rescan();
+            worker.rescan();
+
+            // then
+            then(chainIndexer).should(times(2)).indexBlock(100L);
+        }
+
+        @Test
+        @DisplayName("gives up after max attempts")
+        void givesUpAfterMaxAttempts() {
+            // given
+            given(blockProgressStore.getFailedBlocks(ETHEREUM)).willReturn(Set.of(100L));
+            given(chainIndexer.indexBlock(100L)).willThrow(new RuntimeException("RPC error"));
+
+            // when — call rescan MAX_ATTEMPTS + 1 times
+            for (var i = 0; i < MAX_ATTEMPTS + 1; i++) {
+                worker.rescan();
+            }
+
+            // then — indexBlock called MAX_ATTEMPTS times (not MAX_ATTEMPTS + 1)
+            then(chainIndexer).should(times(MAX_ATTEMPTS)).indexBlock(100L);
+        }
+
+        @Test
+        @DisplayName("processes multiple failed blocks in order")
+        void processesMultipleFailedBlocksInOrder() {
+            // given
+            given(blockProgressStore.getFailedBlocks(ETHEREUM)).willReturn(Set.of(300L, 100L, 200L));
+            var blockResult = aBlockResult().transfers(List.of()).build();
+            given(chainIndexer.indexBlock(100L)).willReturn(blockResult);
+            given(chainIndexer.indexBlock(200L)).willReturn(blockResult);
+            given(chainIndexer.indexBlock(300L)).willReturn(blockResult);
+
+            // when
+            worker.rescan();
+
+            // then
+            var inOrder = inOrder(chainIndexer);
+            then(chainIndexer).should(inOrder).indexBlock(100L);
+            then(chainIndexer).should(inOrder).indexBlock(200L);
+            then(chainIndexer).should(inOrder).indexBlock(300L);
+        }
+
+        @Test
+        @DisplayName("keeps block in failed set after max attempts")
+        void keepsBlockInFailedSetAfterMaxAttempts() {
+            // given
+            given(blockProgressStore.getFailedBlocks(ETHEREUM)).willReturn(Set.of(100L));
+            given(chainIndexer.indexBlock(100L)).willThrow(new RuntimeException("RPC error"));
+
+            // when
+            for (var i = 0; i < MAX_ATTEMPTS + 1; i++) {
+                worker.rescan();
+            }
+
+            // then
+            then(blockProgressStore).should(never()).removeFailedBlock(ETHEREUM, 100L);
+        }
+    }
+
+    @Nested
+    @DisplayName("calculateBackoff")
+    class CalculateBackoff {
+
+        @Test
+        @DisplayName("returns exponential backoff")
+        void returnsExponentialBackoff() {
+            // given — worker created in setUp
+
+            // when / then
+            assertThat(worker.calculateBackoff(1)).isEqualTo(1000L);
+            assertThat(worker.calculateBackoff(2)).isEqualTo(2000L);
+            assertThat(worker.calculateBackoff(3)).isEqualTo(4000L);
+            assertThat(worker.calculateBackoff(4)).isEqualTo(8000L);
+            assertThat(worker.calculateBackoff(5)).isEqualTo(16000L);
+        }
+
+        @Test
+        @DisplayName("caps at 30 seconds")
+        void capsAt30Seconds() {
+            // given — worker created in setUp
+
+            // when / then
+            assertThat(worker.calculateBackoff(6)).isEqualTo(30000L);
+            assertThat(worker.calculateBackoff(10)).isEqualTo(30000L);
+        }
+    }
+
+    @Nested
+    @DisplayName("getWorkerType")
+    class GetWorkerType {
+
+        @Test
+        @DisplayName("returns RESCAN")
+        void returnsRescan() {
+            // given — worker created in setUp
+
+            // when
+            var workerType = worker.getWorkerType();
+
+            // then
+            assertThat(workerType).isEqualTo(RESCAN);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `RescanWorker` extending `BaseWorker` that retries failed blocks with exponential backoff (1s, 2s, 4s, 8s, 16s, capped at 30s)
- Tracks retry attempts in-memory via `ConcurrentHashMap`; gives up after 5 attempts (leaves block in failed set for manual investigation)
- Processes failed blocks in sorted (ascending) order for deterministic retry behavior

## Test plan
- [x] Verify block is removed from failed set on successful rescan
- [x] Verify no-op when no failed blocks exist
- [x] Verify attempt count increments on failure
- [x] Verify gives up after MAX_ATTEMPTS (5) and stops calling indexBlock
- [x] Verify failed blocks are processed in sorted order
- [x] Verify block remains in failed set after max attempts (not removed)
- [x] Verify exponential backoff calculation (1s, 2s, 4s, 8s, 16s)
- [x] Verify backoff caps at 30 seconds
- [x] Verify getWorkerType returns RESCAN
- [x] `./gradlew build` passes (compile + Spotless + all tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)