### PR TITLE
SBI-32: Add Prometheus metrics and alerting rules

### DIFF
--- a/infra/prometheus/alerts.yml
+++ b/infra/prometheus/alerts.yml
@@ -1,0 +1,68 @@
+groups:
+  - name: indexer-alerts
+    rules:
+      - alert: IndexerChainLagHigh
+        expr: indexer_chain_lag > 50
+        for: 5m
+        labels:
+          severity: critical
+          priority: P1
+        annotations:
+          summary: "Chain {{ $labels.chain }} lag exceeds 50 blocks"
+          description: "Chain {{ $labels.chain }} has been lagging behind by {{ $value }} blocks for more than 5 minutes."
+          runbook: "Check RPC health, network congestion, and worker state."
+
+      - alert: IndexerChainDown
+        expr: up{job="indexer"} == 0
+        for: 3m
+        labels:
+          severity: critical
+          priority: P1
+        annotations:
+          summary: "Indexer instance is down"
+          description: "Indexer has been unreachable for more than 3 minutes."
+          runbook: "Check application health, restart if needed."
+
+      - alert: IndexerKafkaPublishFailed
+        expr: rate(indexer_kafka_publish_failed_total[1m]) > 0
+        for: 1m
+        labels:
+          severity: critical
+          priority: P1
+        annotations:
+          summary: "Kafka publish failures detected on chain {{ $labels.chain }}"
+          description: "Transfer events are failing to publish to Kafka on chain {{ $labels.chain }}. This may cause missed deposits."
+          runbook: "Check Kafka broker health, topic configuration, and network connectivity."
+
+      - alert: IndexerRpcErrorRate
+        expr: rate(indexer_rpc_latency_seconds_count{exception!="none"}[2m]) / rate(indexer_rpc_latency_seconds_count[2m]) > 0.5
+        for: 2m
+        labels:
+          severity: warning
+          priority: P2
+        annotations:
+          summary: "High RPC error rate on chain {{ $labels.chain }}"
+          description: "RPC error rate exceeds 50% on chain {{ $labels.chain }} for method {{ $labels.method }}."
+          runbook: "Check RPC provider status, consider switching to backup RPC."
+
+      - alert: IndexerFailedBlocks
+        expr: indexer_blocks_failed_total > 10
+        for: 5m
+        labels:
+          severity: warning
+          priority: P2
+        annotations:
+          summary: "More than 10 failed blocks on chain {{ $labels.chain }}"
+          description: "Chain {{ $labels.chain }} has {{ $value }} failed blocks. RescanWorker should be retrying these."
+          runbook: "Check RescanWorker state and failed block reasons."
+
+      - alert: IndexerBloomFilterEmpty
+        expr: indexer_bloom_size == 0
+        for: 5m
+        labels:
+          severity: warning
+          priority: P2
+        annotations:
+          summary: "Bloom filter empty for network type {{ $labels.networkType }}"
+          description: "No addresses loaded in bloom filter for {{ $labels.networkType }}. No transfers will be matched."
+          runbook: "Check wallet address database and bloom filter initialization."

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/application/config/ChainAutoConfiguration.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/application/config/ChainAutoConfiguration.java
@@ -8,6 +8,7 @@ import com.stablebridge.indexer.domain.port.ChainIndexer;
 import com.stablebridge.indexer.infrastructure.chain.evm.EvmChainConfig;
 import com.stablebridge.indexer.infrastructure.chain.evm.EvmChainIndexerFactory;
 import com.stablebridge.indexer.infrastructure.chain.evm.EvmChainTokenConfig;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,11 +25,12 @@ class ChainAutoConfiguration {
 
     @Bean
     List<ChainIndexer> chainIndexers(IndexerProperties indexerProperties,
-                                      ObjectMapper objectMapper) {
+                                      ObjectMapper objectMapper,
+                                      MeterRegistry meterRegistry) {
         var indexers = indexerProperties.chains().entrySet().stream()
                 .filter(entry -> entry.getValue().enabled())
                 .filter(entry -> EVM_CHAIN_TYPE.equals(entry.getValue().type()))
-                .map(entry -> createEvmChainIndexer(entry.getKey(), entry.getValue(), objectMapper))
+                .map(entry -> createEvmChainIndexer(entry.getKey(), entry.getValue(), objectMapper, meterRegistry))
                 .toList();
 
         log.info("Auto-configured {} EVM chain indexers", indexers.size());
@@ -37,9 +39,10 @@ class ChainAutoConfiguration {
 
     private static ChainIndexer createEvmChainIndexer(String networkId,
                                                        ChainProperties chainProperties,
-                                                       ObjectMapper objectMapper) {
+                                                       ObjectMapper objectMapper,
+                                                       MeterRegistry meterRegistry) {
         var config = toEvmChainConfig(networkId, chainProperties);
-        return EvmChainIndexerFactory.create(config, objectMapper);
+        return EvmChainIndexerFactory.create(config, objectMapper, meterRegistry);
     }
 
     static EvmChainConfig toEvmChainConfig(String networkId,

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/application/config/GuavaBloomAutoConfiguration.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/application/config/GuavaBloomAutoConfiguration.java
@@ -3,6 +3,7 @@ package com.stablebridge.indexer.application.config;
 import com.stablebridge.indexer.application.properties.BloomProperties;
 import com.stablebridge.indexer.domain.port.WalletAddressRepository;
 import com.stablebridge.indexer.infrastructure.bloom.GuavaBloomAddressFilter;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,11 +15,13 @@ public class GuavaBloomAutoConfiguration {
     @Bean
     GuavaBloomAddressFilter guavaBloomAddressFilter(
             BloomProperties bloomProperties,
-            WalletAddressRepository walletAddressRepository) {
+            WalletAddressRepository walletAddressRepository,
+            MeterRegistry meterRegistry) {
         return new GuavaBloomAddressFilter(
                 bloomProperties.expectedInsertions(),
                 bloomProperties.errorRate(),
-                walletAddressRepository
+                walletAddressRepository,
+                meterRegistry
         );
     }
 }

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/application/config/RedisBloomAutoConfiguration.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/application/config/RedisBloomAutoConfiguration.java
@@ -3,6 +3,7 @@ package com.stablebridge.indexer.application.config;
 import com.stablebridge.indexer.application.properties.BloomProperties;
 import com.stablebridge.indexer.domain.port.WalletAddressRepository;
 import com.stablebridge.indexer.infrastructure.bloom.RedisBloomAddressFilter;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,12 +17,14 @@ public class RedisBloomAutoConfiguration {
     RedisBloomAddressFilter redisBloomAddressFilter(
             StringRedisTemplate stringRedisTemplate,
             BloomProperties bloomProperties,
-            WalletAddressRepository walletAddressRepository) {
+            WalletAddressRepository walletAddressRepository,
+            MeterRegistry meterRegistry) {
         return new RedisBloomAddressFilter(
                 stringRedisTemplate,
                 bloomProperties.expectedInsertions(),
                 bloomProperties.errorRate(),
-                walletAddressRepository
+                walletAddressRepository,
+                meterRegistry
         );
     }
 }

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/domain/service/BaseWorker.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/domain/service/BaseWorker.java
@@ -39,6 +39,7 @@ public abstract class BaseWorker {
     private final WalletAddressRepository walletAddressRepository;
     private final Counter blocksProcessedCounter;
     private final Counter transfersMatchedCounter;
+    private final Counter blocksFailedCounter;
     private final AtomicReference<WorkerState> state = new AtomicReference<>(STOPPED);
 
     protected BaseWorker(
@@ -57,6 +58,9 @@ public abstract class BaseWorker {
                 .tag("chain", chainIndexer.getChainId().name())
                 .register(meterRegistry);
         this.transfersMatchedCounter = Counter.builder("indexer.transfers.matched")
+                .tag("chain", chainIndexer.getChainId().name())
+                .register(meterRegistry);
+        this.blocksFailedCounter = Counter.builder("indexer.blocks.failed")
                 .tag("chain", chainIndexer.getChainId().name())
                 .register(meterRegistry);
     }
@@ -119,6 +123,9 @@ public abstract class BaseWorker {
             blocksProcessedCounter.increment();
 
             log.debug("Block processed successfully — blockNumber={}", blockNumber);
+        } catch (Exception e) {
+            blocksFailedCounter.increment();
+            throw e;
         } finally {
             clearMdcContext();
         }

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/domain/service/RegularWorker.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/domain/service/RegularWorker.java
@@ -6,10 +6,12 @@ import com.stablebridge.indexer.domain.port.BlockProgressStore;
 import com.stablebridge.indexer.domain.port.ChainIndexer;
 import com.stablebridge.indexer.domain.port.TransferEventPublisher;
 import com.stablebridge.indexer.domain.port.WalletAddressRepository;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.stablebridge.indexer.domain.model.WorkerType.REGULAR;
 
@@ -19,6 +21,7 @@ public class RegularWorker extends BaseWorker {
     private final Duration pollInterval;
     private final int batchSize;
     private final long startBlock;
+    private final AtomicLong chainLag = new AtomicLong(0);
 
     public RegularWorker(
             ChainIndexer chainIndexer,
@@ -35,6 +38,9 @@ public class RegularWorker extends BaseWorker {
         this.pollInterval = pollInterval;
         this.batchSize = batchSize;
         this.startBlock = startBlock;
+        Gauge.builder("indexer.chain.lag", chainLag, AtomicLong::get)
+                .tag("chain", chainIndexer.getChainId().name())
+                .register(meterRegistry);
     }
 
     @Override
@@ -55,6 +61,7 @@ public class RegularWorker extends BaseWorker {
         }
 
         var lag = latestFinalized - lastProcessed;
+        chainLag.set(lag);
         if (lag > batchSize * 10L) {
             log.warn("Block lag exceeds threshold — chain={}, lag={}, latestFinalized={}, lastProcessed={}",
                     getChainId(), lag, latestFinalized, lastProcessed);

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/bloom/GuavaBloomAddressFilter.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/bloom/GuavaBloomAddressFilter.java
@@ -5,6 +5,8 @@ import com.google.common.hash.Funnels;
 import com.stablebridge.indexer.domain.model.NetworkType;
 import com.stablebridge.indexer.domain.port.AddressFilter;
 import com.stablebridge.indexer.domain.port.WalletAddressRepository;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,13 +40,17 @@ public class GuavaBloomAddressFilter implements AddressFilter {
     private final long expectedInsertions;
     private final double errorRate;
     private final WalletAddressRepository walletAddressRepository;
+    private final MeterRegistry meterRegistry;
 
     private final ConcurrentHashMap<NetworkType, BloomFilter<String>> filters = new ConcurrentHashMap<>();
 
     @PostConstruct
     void initialize() {
         for (NetworkType networkType : NetworkType.values()) {
-            filters.computeIfAbsent(networkType, this::createBloomFilter);
+            var filter = filters.computeIfAbsent(networkType, this::createBloomFilter);
+            Gauge.builder("indexer.bloom.size", filter, BloomFilter::approximateElementCount)
+                    .tag("networkType", networkType.name())
+                    .register(meterRegistry);
         }
         log.info("Initialized Guava bloom filters for all network types — expectedInsertions={}, errorRate={}",
                 expectedInsertions, errorRate);

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/bloom/RedisBloomAddressFilter.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/bloom/RedisBloomAddressFilter.java
@@ -3,6 +3,8 @@ package com.stablebridge.indexer.infrastructure.bloom;
 import com.stablebridge.indexer.domain.model.NetworkType;
 import com.stablebridge.indexer.domain.port.AddressFilter;
 import com.stablebridge.indexer.domain.port.WalletAddressRepository;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,6 +12,8 @@ import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Redis Bloom filter implementation of {@link AddressFilter}.
@@ -40,11 +44,17 @@ public class RedisBloomAddressFilter implements AddressFilter {
     private final long expectedInsertions;
     private final double errorRate;
     private final WalletAddressRepository walletAddressRepository;
+    private final MeterRegistry meterRegistry;
+    private final ConcurrentHashMap<NetworkType, AtomicLong> bloomSizes = new ConcurrentHashMap<>();
 
     @PostConstruct
     void initializeFilters() {
         for (NetworkType networkType : NetworkType.values()) {
             initializeFilter(networkType);
+            var size = bloomSizes.computeIfAbsent(networkType, nt -> new AtomicLong(0));
+            Gauge.builder("indexer.bloom.size", size, AtomicLong::get)
+                    .tag("networkType", networkType.name())
+                    .register(meterRegistry);
         }
         log.info("Initialized Redis bloom filters for all network types — expectedInsertions={}, errorRate={}",
                 expectedInsertions, errorRate);
@@ -71,15 +81,16 @@ public class RedisBloomAddressFilter implements AddressFilter {
 
     @Override
     public void add(String address, NetworkType networkType) {
-        String key = bloomKey(networkType);
+        var key = bloomKey(networkType);
         redisTemplate.execute((RedisCallback<Boolean>) connection -> {
-            Object rawResult = connection.commands().execute(
+            var rawResult = connection.commands().execute(
                     "BF.ADD",
                     key.getBytes(StandardCharsets.UTF_8),
                     address.getBytes(StandardCharsets.UTF_8)
             );
             return parseBooleanReply(rawResult);
         });
+        bloomSizes.computeIfAbsent(networkType, nt -> new AtomicLong(0)).incrementAndGet();
         log.debug("Added address to Redis bloom filter — networkType={}, address={}", networkType, address);
     }
 

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmChainIndexerFactory.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmChainIndexerFactory.java
@@ -3,6 +3,7 @@ package com.stablebridge.indexer.infrastructure.chain.evm;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stablebridge.indexer.domain.model.ChainId;
 import com.stablebridge.indexer.domain.port.ChainIndexer;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,7 +24,8 @@ public class EvmChainIndexerFactory {
             "bsc_mainnet", ChainId.BSC
     );
 
-    public static ChainIndexer create(EvmChainConfig config, ObjectMapper objectMapper) {
+    public static ChainIndexer create(EvmChainConfig config, ObjectMapper objectMapper,
+                                      MeterRegistry meterRegistry) {
         var chainId = resolveChainId(config.networkId());
 
         var rpcClient = new EvmRpcClient(
@@ -39,7 +41,8 @@ public class EvmChainIndexerFactory {
                 config.networkId(),
                 config.maxRetries(),
                 config.rateLimitRps(),
-                config.rateLimitBurst()
+                config.rateLimitBurst(),
+                meterRegistry
         );
 
         var nativeTransferParser = new EvmNativeTransferParser(chainId, config.nativeDecimals());

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/evm/ResilientEvmRpcClient.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/evm/ResilientEvmRpcClient.java
@@ -9,6 +9,8 @@ import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
@@ -33,14 +35,16 @@ class ResilientEvmRpcClient {
     private final CircuitBreaker circuitBreaker;
     private final Retry retry;
     private final RateLimiter rateLimiter;
+    private final MeterRegistry meterRegistry;
 
     ResilientEvmRpcClient(EvmRpcClient delegate, String chainName, int maxRetries,
-                          int rateLimitRps, int rateLimitBurst) {
+                          int rateLimitRps, int rateLimitBurst, MeterRegistry meterRegistry) {
         this.delegate = delegate;
         this.chainName = chainName;
         this.circuitBreaker = createCircuitBreaker(chainName);
         this.retry = createRetry(chainName, maxRetries);
         this.rateLimiter = createRateLimiter(chainName, rateLimitRps, rateLimitBurst);
+        this.meterRegistry = meterRegistry;
     }
 
     long getLatestBlockNumber() {
@@ -76,6 +80,7 @@ class ResilientEvmRpcClient {
     }
 
     private <T> T executeWithResilience(Supplier<T> supplier, String methodName) {
+        var sample = Timer.start(meterRegistry);
         var decorated = decorateSupplier(supplier);
         try {
             return decorated.get();
@@ -85,6 +90,11 @@ class ResilientEvmRpcClient {
         } catch (RequestNotPermitted e) {
             log.warn("Rate limiter rejected call for chain={}, method={}", chainName, methodName);
             throw EvmRpcResilienceException.rateLimited(chainName);
+        } finally {
+            sample.stop(Timer.builder("indexer.rpc.latency")
+                    .tag("chain", chainName)
+                    .tag("method", methodName)
+                    .register(meterRegistry));
         }
     }
 

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/messaging/KafkaTransferEventPublisher.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/messaging/KafkaTransferEventPublisher.java
@@ -3,12 +3,15 @@ package com.stablebridge.indexer.infrastructure.messaging;
 import com.stablebridge.indexer.api.TransferEvent;
 import com.stablebridge.indexer.domain.event.TransferDetectedEvent;
 import com.stablebridge.indexer.domain.port.TransferEventPublisher;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Kafka-based implementation of {@link TransferEventPublisher}.
@@ -29,23 +32,38 @@ class KafkaTransferEventPublisher implements TransferEventPublisher {
 
     private final KafkaTemplate<String, TransferEvent> kafkaTemplate;
     private final TransferEventMapper transferEventMapper;
+    private final MeterRegistry meterRegistry;
+    private final ConcurrentHashMap<String, Counter> failureCounters = new ConcurrentHashMap<>();
 
     @Override
     public void publish(TransferDetectedEvent event) {
-        TransferEvent transferEvent = transferEventMapper.toTransferEvent(event);
-        String topic = TOPIC_PREFIX + event.transfer().chainId().name();
-        String key = event.transfer().toAddress();
+        var transferEvent = transferEventMapper.toTransferEvent(event);
+        var chain = event.transfer().chainId().name();
+        var topic = TOPIC_PREFIX + chain;
+        var key = event.transfer().toAddress();
 
         log.info("Publishing transfer event to topic={}, key={}, txHash={}",
                 topic, key, transferEvent.txHash());
 
-        kafkaTemplate.send(topic, key, transferEvent);
+        kafkaTemplate.send(topic, key, transferEvent)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        failureCounter(chain).increment();
+                        log.error("Failed to publish transfer event — topic={}, key={}, error={}",
+                                topic, key, ex.getMessage());
+                    }
+                });
     }
 
     @Override
     public void publishAll(List<TransferDetectedEvent> events) {
-        for (TransferDetectedEvent event : events) {
-            publish(event);
-        }
+        events.forEach(this::publish);
+    }
+
+    private Counter failureCounter(String chain) {
+        return failureCounters.computeIfAbsent(chain, c ->
+                Counter.builder("indexer.kafka.publish.failed")
+                        .tag("chain", c)
+                        .register(meterRegistry));
     }
 }

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/application/config/ChainAutoConfigurationTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/application/config/ChainAutoConfigurationTest.java
@@ -8,6 +8,8 @@ import com.stablebridge.indexer.application.properties.RpcProperties;
 import com.stablebridge.indexer.application.properties.TokenContractProperties;
 import com.stablebridge.indexer.infrastructure.chain.evm.EvmChainConfig;
 import com.stablebridge.indexer.infrastructure.chain.evm.EvmChainTokenConfig;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ChainAutoConfigurationTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final MeterRegistry METER_REGISTRY = new SimpleMeterRegistry();
 
     private final ChainAutoConfiguration configuration = new ChainAutoConfiguration();
 
@@ -44,7 +47,7 @@ class ChainAutoConfigurationTest {
             var indexerProperties = new IndexerProperties(chains, null, null);
 
             // when
-            var indexers = configuration.chainIndexers(indexerProperties, OBJECT_MAPPER);
+            var indexers = configuration.chainIndexers(indexerProperties, OBJECT_MAPPER, METER_REGISTRY);
 
             // then
             assertThat(indexers).hasSize(2);
@@ -63,7 +66,7 @@ class ChainAutoConfigurationTest {
             var indexerProperties = new IndexerProperties(chains, null, null);
 
             // when
-            var indexers = configuration.chainIndexers(indexerProperties, OBJECT_MAPPER);
+            var indexers = configuration.chainIndexers(indexerProperties, OBJECT_MAPPER, METER_REGISTRY);
 
             // then
             assertThat(indexers).hasSize(1);
@@ -80,7 +83,7 @@ class ChainAutoConfigurationTest {
             var indexerProperties = new IndexerProperties(chains, null, null);
 
             // when
-            var indexers = configuration.chainIndexers(indexerProperties, OBJECT_MAPPER);
+            var indexers = configuration.chainIndexers(indexerProperties, OBJECT_MAPPER, METER_REGISTRY);
 
             // then
             assertThat(indexers).isEmpty();
@@ -93,7 +96,7 @@ class ChainAutoConfigurationTest {
             var indexerProperties = new IndexerProperties(Map.of(), null, null);
 
             // when
-            var indexers = configuration.chainIndexers(indexerProperties, OBJECT_MAPPER);
+            var indexers = configuration.chainIndexers(indexerProperties, OBJECT_MAPPER, METER_REGISTRY);
 
             // then
             assertThat(indexers).isEmpty();

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/domain/service/BaseWorkerTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/domain/service/BaseWorkerTest.java
@@ -37,6 +37,7 @@ import static com.stablebridge.indexer.testutil.TransferFixtures.DEFAULT_TO_ADDR
 import static com.stablebridge.indexer.testutil.TransferFixtures.aBlockResult;
 import static com.stablebridge.indexer.testutil.TransferFixtures.aTransfer;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.inOrder;
@@ -463,6 +464,22 @@ class BaseWorkerTest {
                     .counter();
             assertThat(counter).isNotNull();
             assertThat(counter.count()).isEqualTo(0.0);
+        }
+
+        @Test
+        @DisplayName("increments blocks failed counter when processBlock throws")
+        void incrementsBlocksFailedCounterWhenProcessBlockThrows() {
+            // given
+            given(chainIndexer.indexBlock(DEFAULT_BLOCK_NUMBER))
+                    .willThrow(new RuntimeException("RPC error"));
+
+            // when
+            assertThatThrownBy(() -> worker.processBlock(DEFAULT_BLOCK_NUMBER))
+                    .isInstanceOf(RuntimeException.class);
+
+            // then
+            assertThat(meterRegistry.counter("indexer.blocks.failed", "chain", "ETHEREUM").count())
+                    .isEqualTo(1.0);
         }
     }
 

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/domain/service/RegularWorkerTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/domain/service/RegularWorkerTest.java
@@ -162,6 +162,25 @@ class RegularWorkerTest {
         }
 
         @Test
+        @DisplayName("updates chain lag gauge after polling")
+        void updatesChainLagGaugeAfterPolling() {
+            // given
+            given(chainIndexer.getLatestFinalizedBlockNumber()).willReturn(150L);
+            given(blockProgressStore.getLastProcessedBlock(ETHEREUM)).willReturn(OptionalLong.of(100L));
+            for (var block = 101L; block <= 110L; block++) {
+                given(chainIndexer.indexBlock(block)).willReturn(aBlockResult().transfers(List.of()).build());
+            }
+
+            // when
+            worker.poll();
+
+            // then
+            var lagGauge = meterRegistry.find("indexer.chain.lag").tag("chain", "ETHEREUM").gauge();
+            assertThat(lagGauge).isNotNull();
+            assertThat(lagGauge.value()).isEqualTo(50.0);
+        }
+
+        @Test
         @DisplayName("processes exactly one block when one block behind")
         void processesExactlyOneBlockWhenOneBlockBehind() {
             // given

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/bloom/GuavaBloomAddressFilterTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/bloom/GuavaBloomAddressFilterTest.java
@@ -2,6 +2,8 @@ package com.stablebridge.indexer.infrastructure.bloom;
 
 import com.stablebridge.indexer.domain.model.NetworkType;
 import com.stablebridge.indexer.domain.port.WalletAddressRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -29,11 +31,15 @@ class GuavaBloomAddressFilterTest {
     @Mock
     private WalletAddressRepository walletAddressRepository;
 
+    private MeterRegistry meterRegistry;
+
     private GuavaBloomAddressFilter filter;
 
     @BeforeEach
     void setUp() {
-        filter = new GuavaBloomAddressFilter(EXPECTED_INSERTIONS, ERROR_RATE, walletAddressRepository);
+        meterRegistry = new SimpleMeterRegistry();
+        filter = new GuavaBloomAddressFilter(
+                EXPECTED_INSERTIONS, ERROR_RATE, walletAddressRepository, meterRegistry);
         filter.initialize();
     }
 
@@ -118,14 +124,29 @@ class GuavaBloomAddressFilterTest {
         @Test
         @DisplayName("supports adding to different network types independently")
         void supportsMultipleNetworkTypes() {
+            // given / when
             filter.add(ADDRESS, EVM);
             filter.add(ADDRESS, SOLANA);
 
-            boolean evmResult = filter.mightContain(ADDRESS, EVM);
-            boolean solanaResult = filter.mightContain(ADDRESS, SOLANA);
+            // then
+            assertThat(filter.mightContain(ADDRESS, EVM)).isTrue();
+            assertThat(filter.mightContain(ADDRESS, SOLANA)).isTrue();
+        }
 
-            assertThat(evmResult).isTrue();
-            assertThat(solanaResult).isTrue();
+        @Test
+        @DisplayName("registers bloom size gauge reflecting approximate element count")
+        void registersBloomSizeGaugeReflectingApproximateElementCount() {
+            // given
+            filter.add(ADDRESS, EVM);
+
+            // when
+            var gauge = meterRegistry.find("indexer.bloom.size")
+                    .tag("networkType", "EVM")
+                    .gauge();
+
+            // then
+            assertThat(gauge).isNotNull();
+            assertThat(gauge.value()).isGreaterThan(0.0);
         }
     }
 

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/bloom/RedisBloomAddressFilterTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/bloom/RedisBloomAddressFilterTest.java
@@ -2,6 +2,8 @@ package com.stablebridge.indexer.infrastructure.bloom;
 
 import com.stablebridge.indexer.domain.model.NetworkType;
 import com.stablebridge.indexer.domain.port.WalletAddressRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -48,17 +50,19 @@ class RedisBloomAddressFilterTest {
     private WalletAddressRepository walletAddressRepository;
 
     private StringRedisTemplate redisTemplate;
+    private MeterRegistry meterRegistry;
     private RedisBloomAddressFilter filter;
 
     @BeforeEach
     void setUp() {
         lenient().when(connectionFactory.getConnection()).thenReturn(redisConnection);
         lenient().when(redisConnection.commands()).thenReturn(redisCommands);
+        meterRegistry = new SimpleMeterRegistry();
         redisTemplate = new StringRedisTemplate();
         redisTemplate.setConnectionFactory(connectionFactory);
         redisTemplate.afterPropertiesSet();
         filter = new RedisBloomAddressFilter(
-                redisTemplate, EXPECTED_INSERTIONS, ERROR_RATE, walletAddressRepository);
+                redisTemplate, EXPECTED_INSERTIONS, ERROR_RATE, walletAddressRepository, meterRegistry);
     }
 
     @Nested
@@ -180,12 +184,34 @@ class RedisBloomAddressFilterTest {
         @Test
         @DisplayName("sends BF.ADD command with correct key and address")
         void sendsBfAddCommand() {
+            // given
             given(redisCommands.execute("BF.ADD", BLOOM_KEY_BYTES, ADDRESS_BYTES))
                     .willReturn(1L);
 
+            // when
             filter.add(TEST_ADDRESS, TEST_NETWORK);
 
+            // then
             then(redisCommands).should().execute("BF.ADD", BLOOM_KEY_BYTES, ADDRESS_BYTES);
+        }
+
+        @Test
+        @DisplayName("increments bloom size gauge when address is added")
+        void incrementsBloomSizeGaugeWhenAddressIsAdded() {
+            // given
+            filter.initializeFilters();
+            given(redisCommands.execute("BF.ADD", BLOOM_KEY_BYTES, ADDRESS_BYTES))
+                    .willReturn(1L);
+
+            // when
+            filter.add(TEST_ADDRESS, TEST_NETWORK);
+
+            // then
+            var gauge = meterRegistry.find("indexer.bloom.size")
+                    .tag("networkType", "EVM")
+                    .gauge();
+            assertThat(gauge).isNotNull();
+            assertThat(gauge.value()).isEqualTo(1.0);
         }
     }
 

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmChainIndexerE2eTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmChainIndexerE2eTest.java
@@ -6,6 +6,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.stablebridge.indexer.domain.model.BlockResult;
 import com.stablebridge.indexer.domain.model.IndexedBlock;
 import com.stablebridge.indexer.domain.model.Transfer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -74,7 +75,7 @@ class EvmChainIndexerE2eTest {
         var rpcClient = new EvmRpcClient(
                 wmRuntimeInfo.getHttpBaseUrl(), BATCH_SIZE, false, TIMEOUT, objectMapper);
         var resilientClient = new ResilientEvmRpcClient(
-                rpcClient, "test_chain", 1, 100, 100);
+                rpcClient, "test_chain", 1, 100, 100, new SimpleMeterRegistry());
 
         var usdcConfig = EvmTokenConfig.builder()
                 .address(USDC_CONTRACT)

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmChainIndexerFactoryTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/evm/EvmChainIndexerFactoryTest.java
@@ -1,6 +1,8 @@
 package com.stablebridge.indexer.infrastructure.chain.evm;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class EvmChainIndexerFactoryTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final MeterRegistry METER_REGISTRY = new SimpleMeterRegistry();
 
     @Nested
     @DisplayName("create")
@@ -30,7 +33,7 @@ class EvmChainIndexerFactoryTest {
             var config = anEvmChainConfig("ethereum_mainnet", true, 0);
 
             // when
-            var indexer = EvmChainIndexerFactory.create(config, OBJECT_MAPPER);
+            var indexer = EvmChainIndexerFactory.create(config, OBJECT_MAPPER, METER_REGISTRY);
 
             // then
             assertThat(indexer.getChainId()).isEqualTo(ETHEREUM);
@@ -43,7 +46,7 @@ class EvmChainIndexerFactoryTest {
             var config = anEvmChainConfig("polygon_mainnet", false, 128);
 
             // when
-            var indexer = EvmChainIndexerFactory.create(config, OBJECT_MAPPER);
+            var indexer = EvmChainIndexerFactory.create(config, OBJECT_MAPPER, METER_REGISTRY);
 
             // then
             assertThat(indexer.getChainId()).isEqualTo(POLYGON);
@@ -56,7 +59,7 @@ class EvmChainIndexerFactoryTest {
             var config = anEvmChainConfig("base_mainnet", false, 10);
 
             // when
-            var indexer = EvmChainIndexerFactory.create(config, OBJECT_MAPPER);
+            var indexer = EvmChainIndexerFactory.create(config, OBJECT_MAPPER, METER_REGISTRY);
 
             // then
             assertThat(indexer.getChainId()).isEqualTo(BASE);
@@ -77,7 +80,7 @@ class EvmChainIndexerFactoryTest {
             var config = anEvmChainConfigWithTokens("ethereum_mainnet", tokenContracts);
 
             // when
-            var indexer = EvmChainIndexerFactory.create(config, OBJECT_MAPPER);
+            var indexer = EvmChainIndexerFactory.create(config, OBJECT_MAPPER, METER_REGISTRY);
 
             // then
             assertThat(indexer).isNotNull();

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/evm/ResilientEvmRpcClientTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/evm/ResilientEvmRpcClientTest.java
@@ -1,6 +1,8 @@
 package com.stablebridge.indexer.infrastructure.chain.evm;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -33,12 +35,15 @@ class ResilientEvmRpcClientTest {
     @Mock
     private EvmRpcClient delegate;
 
+    private MeterRegistry meterRegistry;
+
     private ResilientEvmRpcClient resilientClient;
 
     @BeforeEach
     void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
         resilientClient = new ResilientEvmRpcClient(
-                delegate, CHAIN_NAME, MAX_RETRIES, RATE_LIMIT_RPS, RATE_LIMIT_BURST);
+                delegate, CHAIN_NAME, MAX_RETRIES, RATE_LIMIT_RPS, RATE_LIMIT_BURST, meterRegistry);
     }
 
     @Nested
@@ -137,6 +142,24 @@ class ResilientEvmRpcClientTest {
 
             // then
             assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("records RPC latency timer for each method call")
+        void recordsRpcLatencyTimerForEachMethodCall() {
+            // given
+            given(delegate.getLatestBlockNumber()).willReturn(BLOCK_NUMBER);
+
+            // when
+            resilientClient.getLatestBlockNumber();
+
+            // then
+            var timer = meterRegistry.find("indexer.rpc.latency")
+                    .tag("chain", CHAIN_NAME)
+                    .tag("method", "getLatestBlockNumber")
+                    .timer();
+            assertThat(timer).isNotNull();
+            assertThat(timer.count()).isEqualTo(1);
         }
     }
 

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/messaging/KafkaTransferEventPublisherTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/messaging/KafkaTransferEventPublisherTest.java
@@ -2,25 +2,32 @@ package com.stablebridge.indexer.infrastructure.messaging;
 
 import com.stablebridge.indexer.api.TransferEvent;
 import com.stablebridge.indexer.domain.event.TransferDetectedEvent;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static com.stablebridge.indexer.domain.model.ChainId.POLYGON;
 import static com.stablebridge.indexer.domain.model.TransferDirection.INCOMING;
 import static com.stablebridge.indexer.testutil.TransferFixtures.DEFAULT_TO_ADDRESS;
 import static com.stablebridge.indexer.testutil.TransferFixtures.aTransfer;
 import static com.stablebridge.indexer.testutil.TransferFixtures.aTransferDetectedEvent;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("KafkaTransferEventPublisher")
 class KafkaTransferEventPublisherTest {
 
     @Mock
@@ -29,11 +36,20 @@ class KafkaTransferEventPublisherTest {
     @Mock
     private TransferEventMapper transferEventMapper;
 
-    @InjectMocks
+    private MeterRegistry meterRegistry;
+
     private KafkaTransferEventPublisher publisher;
 
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = new KafkaTransferEventPublisher(kafkaTemplate, transferEventMapper, meterRegistry);
+    }
+
     @Test
+    @DisplayName("publishes transfer event to correct topic with toAddress key")
     void publish_sendsToCorrectTopicWithToAddressKey() {
+        // given
         var event = aTransferDetectedEvent().build();
         var transfer = event.transfer();
 
@@ -58,9 +74,13 @@ class KafkaTransferEventPublisherTest {
                 event.detectedAt());
 
         given(transferEventMapper.toTransferEvent(event)).willReturn(expectedApiEvent);
+        given(kafkaTemplate.send("transfer.events.ETHEREUM", DEFAULT_TO_ADDRESS, expectedApiEvent))
+                .willReturn(CompletableFuture.completedFuture(null));
 
+        // when
         publisher.publish(event);
 
+        // then
         then(kafkaTemplate).should().send(
                 "transfer.events.ETHEREUM",
                 DEFAULT_TO_ADDRESS,
@@ -68,7 +88,9 @@ class KafkaTransferEventPublisherTest {
     }
 
     @Test
+    @DisplayName("uses chain ID for topic name")
     void publish_usesChainIdForTopicName() {
+        // given
         var polygonTransfer = aTransfer()
                 .chainId(POLYGON)
                 .build();
@@ -99,9 +121,13 @@ class KafkaTransferEventPublisherTest {
                 event.detectedAt());
 
         given(transferEventMapper.toTransferEvent(event)).willReturn(expectedApiEvent);
+        given(kafkaTemplate.send("transfer.events.POLYGON", DEFAULT_TO_ADDRESS, expectedApiEvent))
+                .willReturn(CompletableFuture.completedFuture(null));
 
+        // when
         publisher.publish(event);
 
+        // then
         then(kafkaTemplate).should().send(
                 "transfer.events.POLYGON",
                 DEFAULT_TO_ADDRESS,
@@ -109,7 +135,9 @@ class KafkaTransferEventPublisherTest {
     }
 
     @Test
+    @DisplayName("publishes each event individually when publishAll is called")
     void publishAll_sendsEachEventIndividually() {
+        // given
         var firstTransfer = aTransfer()
                 .toAddress("0xfirst1234567890abcdef1234567890abcdef1234")
                 .build();
@@ -170,9 +198,17 @@ class KafkaTransferEventPublisherTest {
 
         given(transferEventMapper.toTransferEvent(firstEvent)).willReturn(firstApiEvent);
         given(transferEventMapper.toTransferEvent(secondEvent)).willReturn(secondApiEvent);
+        given(kafkaTemplate.send("transfer.events.ETHEREUM",
+                "0xfirst1234567890abcdef1234567890abcdef1234", firstApiEvent))
+                .willReturn(CompletableFuture.completedFuture(null));
+        given(kafkaTemplate.send("transfer.events.ETHEREUM",
+                "0xsecond234567890abcdef1234567890abcdef1234", secondApiEvent))
+                .willReturn(CompletableFuture.completedFuture(null));
 
+        // when
         publisher.publishAll(List.of(firstEvent, secondEvent));
 
+        // then
         then(kafkaTemplate).should().send(
                 "transfer.events.ETHEREUM",
                 "0xfirst1234567890abcdef1234567890abcdef1234",
@@ -184,11 +220,58 @@ class KafkaTransferEventPublisherTest {
     }
 
     @Test
+    @DisplayName("does not send any event when publishAll receives empty list")
     void publishAll_withEmptyList_doesNotSend() {
+        // given — empty list
+
         // when
         publisher.publishAll(List.of());
 
         // then
         then(kafkaTemplate).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("increments failure counter when Kafka send completes exceptionally")
+    void incrementsFailureCounterWhenKafkaSendFails() {
+        // given
+        var event = aTransferDetectedEvent().build();
+        var transfer = event.transfer();
+
+        var apiEvent = new TransferEvent(
+                transfer.txHash(),
+                transfer.fromAddress(),
+                transfer.toAddress(),
+                transfer.rawAmount(),
+                transfer.amount(),
+                transfer.decimals(),
+                transfer.tokenSymbol(),
+                transfer.tokenContractAddress(),
+                transfer.blockNumber(),
+                transfer.blockHash(),
+                transfer.transactionIndex(),
+                transfer.logIndex(),
+                transfer.chainId().name(),
+                transfer.chainId().networkType().name(),
+                transfer.timestamp(),
+                transfer.nativeTransfer(),
+                event.direction().name(),
+                event.detectedAt());
+
+        given(transferEventMapper.toTransferEvent(event)).willReturn(apiEvent);
+        var failedFuture = new CompletableFuture<SendResult<String, TransferEvent>>();
+        failedFuture.completeExceptionally(new RuntimeException("Kafka broker unavailable"));
+        given(kafkaTemplate.send("transfer.events.ETHEREUM", DEFAULT_TO_ADDRESS, apiEvent))
+                .willReturn(failedFuture);
+
+        // when
+        publisher.publish(event);
+
+        // then
+        var counter = meterRegistry.find("indexer.kafka.publish.failed")
+                .tag("chain", "ETHEREUM")
+                .counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(1.0);
     }
 }


### PR DESCRIPTION
## Summary
- Add `indexer.blocks.failed` counter to `BaseWorker` (incremented on `processBlock` exceptions)
- Add `indexer.chain.lag` gauge to `RegularWorker` (updated after each poll cycle)
- Add `indexer.kafka.publish.failed` counter to `KafkaTransferEventPublisher` (async failure tracking via `whenComplete`)
- Add `indexer.bloom.size` gauge to both `RedisBloomAddressFilter` (AtomicLong-backed) and `GuavaBloomAddressFilter` (approximateElementCount)
- Add `indexer.rpc.latency` timer to `ResilientEvmRpcClient` (wraps `executeWithResilience` in Timer.start/stop)
- Create Prometheus alerting rules (`infra/prometheus/alerts.yml`) with 6 alerts: P1 (chain lag, chain down, Kafka failures) and P2 (RPC error rate, failed blocks, empty bloom filters)
- Thread `MeterRegistry` through `EvmChainIndexerFactory`, `ChainAutoConfiguration`, and bloom auto-configurations

## Test plan
- [x] `BaseWorkerTest`: new test verifies `blocks.failed` counter increments on exception
- [x] `RegularWorkerTest`: new test verifies `chain.lag` gauge reflects computed lag value
- [x] `KafkaTransferEventPublisherTest`: new test verifies failure counter increments on async Kafka send failure; existing tests updated to stub `CompletableFuture` return from `send()`
- [x] `RedisBloomAddressFilterTest`: new test verifies `bloom.size` gauge increments on `add()`
- [x] `GuavaBloomAddressFilterTest`: new test verifies `bloom.size` gauge reflects approximate element count
- [x] `ResilientEvmRpcClientTest`: new test verifies `rpc.latency` timer is recorded per method call
- [x] `EvmChainIndexerFactoryTest`, `ChainAutoConfigurationTest`, `EvmChainIndexerE2eTest`: updated constructor/factory calls to pass `SimpleMeterRegistry`
- [x] `./gradlew build` passes (compile + Spotless + all tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Prometheus alerting rules to monitor indexer health metrics including chain lag, instance downtime, Kafka publishing failures, RPC error rates, block processing failures, and bloom filter status.
  * Integrated metrics collection across the indexer to track RPC latency, block processing failures, chain lag, bloom filter capacity, and Kafka publishing performance.

* **Tests**
  * Added comprehensive test coverage for new metrics instrumentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->