### PR TITLE
SBI-45: Add Prometheus scrape config and alerting rules volume mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,12 +53,16 @@ services:
     restart: unless-stopped
 
   prometheus:
-    image: prom/prometheus:v2.53.0
+    image: prom/prometheus:v3.4.0
     container_name: indexer-prometheus
     ports:
       - "9091:9090"
     volumes:
       - ./infra/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./infra/prometheus/alerts.yml:/etc/prometheus/alerts.yml
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.retention.time=30d"
     restart: unless-stopped
 
 volumes:

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - "alerts.yml"
+
+scrape_configs:
+  - job_name: "indexer"
+    metrics_path: "/actuator/prometheus"
+    static_configs:
+      - targets: ["host.docker.internal:8080"]


### PR DESCRIPTION
## Summary
- Add `infra/prometheus/prometheus.yml` with scrape config targeting the indexer's `/actuator/prometheus` endpoint at 15s intervals
- Mount `alerts.yml` into the Prometheus container so the 6 existing alert rules (from SBI-32) are loaded
- Upgrade Prometheus image from v2.53.0 to v3.4.0 with 30-day TSDB retention

## Test plan
- [x] `./gradlew build` passes (no code changes, infrastructure YAML only)
- [ ] `docker compose up prometheus` starts successfully and loads both config files
- [ ] Prometheus UI at `localhost:9091` shows scrape targets and alert rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Prometheus monitoring service from v2.53.0 to v3.4.0
  * Added alerting rules configuration file to support alert generation
  * Configured metrics collection with 15-second scrape intervals from the indexer service
  * Established TSDB data retention policy of 30 days for storage optimization
  * Updated container startup parameters for explicit configuration management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->