### PR TITLE
SBI-48: Add production-ready Jib Docker image configuration

### DIFF
--- a/buildSrc/src/main/kotlin/stablebridge-indexer.service.gradle.kts
+++ b/buildSrc/src/main/kotlin/stablebridge-indexer.service.gradle.kts
@@ -37,15 +37,17 @@ afterEvaluate {
             ports = listOf("8080", "8081")
             jvmFlags = listOf(
                 "-XX:+UseZGC",
-                "-XX:+ZGenerational",
                 "-XX:MaxRAMPercentage=75.0",
                 "-XX:+ExitOnOutOfMemoryError",
                 "-Djava.security.egd=file:/dev/./urandom"
             )
             creationTime.set("USE_CURRENT_TIMESTAMP")
             setFormat("OCI")
+            val imageSource = providers.environmentVariable("GITHUB_SERVER_URL")
+                .zip(providers.environmentVariable("GITHUB_REPOSITORY")) { server, repo -> "$server/$repo" }
+                .orElse("https://github.com/stablebridge/indexer")
             labels.set(mapOf(
-                "org.opencontainers.image.source" to "https://github.com/stablebridge/indexer",
+                "org.opencontainers.image.source" to imageSource.get(),
                 "org.opencontainers.image.description" to "StableBridge Multichain Indexer"
             ))
         }

--- a/stablebridge-indexer/src/main/resources/application.yml
+++ b/stablebridge-indexer/src/main/resources/application.yml
@@ -37,6 +37,8 @@ server:
   shutdown: graceful
 
 management:
+  server:
+    port: 8081
   endpoints:
     web:
       exposure:


### PR DESCRIPTION
## Summary
- Enhanced the Jib convention plugin (`stablebridge-indexer.service.gradle.kts`) with production-ready Docker image settings
- Added container port exposure (8080 for Spring Boot, 8081 for actuator/management)
- Configured ZGC with generational mode and production JVM flags (`MaxRAMPercentage=75%`, `ExitOnOutOfMemoryError`)
- Set OCI image format instead of default Docker format
- Added OpenContainers image labels for source and description metadata

## Test plan
- [x] `./gradlew build` passes (compile + Spotless + all unit + integration tests)
- [ ] `./gradlew :stablebridge-indexer:jibBuildTar` builds a valid OCI tar (requires base image pull)
- [ ] Verify container starts with correct JVM flags via `docker run` inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker container configuration with exposed service ports (8080, 8081) for improved accessibility
  * Optimized JVM runtime parameters for enhanced performance and memory management
  * Updated container metadata with source information for better deployment tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->