### PR TITLE
SBI-35: Add Solana native SOL transfer parser

### DIFF
--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/solana/SolanaNativeTransferParser.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/solana/SolanaNativeTransferParser.java
@@ -1,0 +1,138 @@
+package com.stablebridge.indexer.infrastructure.chain.solana;
+
+import com.stablebridge.indexer.domain.model.ChainId;
+import com.stablebridge.indexer.domain.model.Transfer;
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Slf4j
+class SolanaNativeTransferParser {
+
+    static final String SYSTEM_PROGRAM_ID = "11111111111111111111111111111111";
+    private static final String NATIVE_SYMBOL = "SOL";
+    private static final int SOL_DECIMALS = 9;
+    private static final int NATIVE_TRANSFER_LOG_INDEX = -1;
+    private static final int SYSTEM_TRANSFER_FROM_INDEX = 0;
+    private static final int SYSTEM_TRANSFER_TO_INDEX = 1;
+    private static final int SYSTEM_TRANSFER_ACCOUNT_COUNT = 2;
+
+    private final ChainId chainId;
+
+    SolanaNativeTransferParser(ChainId chainId) {
+        this.chainId = chainId;
+    }
+
+    List<Transfer> parseNativeTransfers(SolanaBlock block, long slot) {
+        if (block.transactions() == null || block.transactions().isEmpty()) {
+            return List.of();
+        }
+
+        var blockHash = block.blockhash();
+        var blockTimestamp = block.blockTimestamp();
+
+        return IntStream.range(0, block.transactions().size())
+                .boxed()
+                .flatMap(txIndex -> parseTransaction(
+                        block.transactions().get(txIndex), txIndex, slot, blockHash, blockTimestamp)
+                        .stream())
+                .toList();
+    }
+
+    private List<Transfer> parseTransaction(SolanaTransaction tx, int txIndex,
+                                            long slot, String blockHash, Instant blockTimestamp) {
+        if (isFailedTransaction(tx)) {
+            return List.of();
+        }
+
+        var message = tx.transaction().message();
+        var accountKeys = message.accountKeys();
+        var instructions = message.instructions();
+
+        if (accountKeys == null || instructions == null) {
+            return List.of();
+        }
+
+        var txHash = tx.transaction().signatures().getFirst();
+
+        return instructions.stream()
+                .filter(this::isSystemProgramTransfer)
+                .map(instruction -> buildTransfer(
+                        instruction, tx.meta(), accountKeys, txHash,
+                        txIndex, slot, blockHash, blockTimestamp))
+                .flatMap(List::stream)
+                .toList();
+    }
+
+    private boolean isFailedTransaction(SolanaTransaction tx) {
+        return tx.meta() != null && tx.meta().err() != null;
+    }
+
+    private boolean isSystemProgramTransfer(SolanaInstruction instruction) {
+        return SYSTEM_PROGRAM_ID.equals(instruction.programId())
+                && instruction.accounts() != null
+                && instruction.accounts().size() >= SYSTEM_TRANSFER_ACCOUNT_COUNT;
+    }
+
+    private List<Transfer> buildTransfer(SolanaInstruction instruction,
+                                         SolanaTransactionMeta meta,
+                                         List<String> accountKeys,
+                                         String txHash, int txIndex,
+                                         long slot, String blockHash,
+                                         Instant blockTimestamp) {
+        var fromAddress = instruction.accounts().get(SYSTEM_TRANSFER_FROM_INDEX);
+        var toAddress = instruction.accounts().get(SYSTEM_TRANSFER_TO_INDEX);
+
+        var toAccountIndex = accountKeys.indexOf(toAddress);
+        if (toAccountIndex < 0 || meta == null) {
+            log.warn("Cannot resolve receiver account index for tx={}", txHash);
+            return List.of();
+        }
+
+        var lamports = computeReceivedLamports(meta, toAccountIndex);
+        if (lamports <= 0) {
+            return List.of();
+        }
+
+        var rawAmount = String.valueOf(lamports);
+        var amount = new BigDecimal(lamports)
+                .divide(BigDecimal.TEN.pow(SOL_DECIMALS), SOL_DECIMALS, RoundingMode.HALF_UP);
+
+        var transfer = Transfer.builder()
+                .txHash(txHash)
+                .fromAddress(fromAddress)
+                .toAddress(toAddress)
+                .rawAmount(rawAmount)
+                .amount(amount)
+                .decimals(SOL_DECIMALS)
+                .tokenSymbol(NATIVE_SYMBOL)
+                .tokenContractAddress(null)
+                .blockNumber(slot)
+                .blockHash(blockHash)
+                .transactionIndex(txIndex)
+                .logIndex(NATIVE_TRANSFER_LOG_INDEX)
+                .chainId(chainId)
+                .timestamp(blockTimestamp)
+                .nativeTransfer(true)
+                .build();
+
+        return List.of(transfer);
+    }
+
+    private long computeReceivedLamports(SolanaTransactionMeta meta, int accountIndex) {
+        var preBalances = meta.preBalances();
+        var postBalances = meta.postBalances();
+
+        if (preBalances == null || postBalances == null
+                || accountIndex >= preBalances.size()
+                || accountIndex >= postBalances.size()) {
+            return 0;
+        }
+
+        return postBalances.get(accountIndex) - preBalances.get(accountIndex);
+    }
+}

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/solana/SolanaNativeTransferParserTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/solana/SolanaNativeTransferParserTest.java
@@ -1,0 +1,457 @@
+package com.stablebridge.indexer.infrastructure.chain.solana;
+
+import com.stablebridge.indexer.domain.model.Transfer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static com.stablebridge.indexer.domain.model.ChainId.SOLANA_CHAIN;
+import static com.stablebridge.indexer.infrastructure.chain.solana.SolanaNativeTransferParser.SYSTEM_PROGRAM_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SolanaNativeTransferParser")
+class SolanaNativeTransferParserTest {
+
+    private static final long SLOT = 166_974_441L;
+    private static final String BLOCK_HASH = "3Eq21vXNB5s86c62bVuUfTeaMif1N2kUqRPBmGRJhyTA";
+    private static final long BLOCK_TIME = 1_700_000_000L;
+    private static final Instant BLOCK_TIMESTAMP = Instant.ofEpochSecond(BLOCK_TIME);
+    private static final String SENDER = "9aE476sH92Vz7DMPyq5WLPkrKWivxeuTKEFKd2sZZcde";
+    private static final String RECEIVER = "HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH";
+    private static final String TX_SIGNATURE = "5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW";
+    private static final int SOL_DECIMALS = 9;
+
+    private final SolanaNativeTransferParser parser = new SolanaNativeTransferParser(SOLANA_CHAIN);
+
+    @Nested
+    @DisplayName("parseNativeTransfers")
+    class ParseNativeTransfers {
+
+        @Test
+        @DisplayName("parses single native SOL transfer with correct amount conversion")
+        void parsesSingleNativeTransfer() {
+            // given
+            var block = aBlockWith(List.of(
+                    aSystemTransferTransaction(SENDER, RECEIVER, TX_SIGNATURE,
+                            5_000L, 2_000_000_000L, 1_000_000_000L)));
+
+            // when
+            var result = parser.parseNativeTransfers(block, SLOT);
+
+            // then
+            var expected = Transfer.builder()
+                    .txHash(TX_SIGNATURE)
+                    .fromAddress(SENDER)
+                    .toAddress(RECEIVER)
+                    .rawAmount("1000000000")
+                    .amount(new BigDecimal("1.000000000"))
+                    .decimals(SOL_DECIMALS)
+                    .tokenSymbol("SOL")
+                    .tokenContractAddress(null)
+                    .blockNumber(SLOT)
+                    .blockHash(BLOCK_HASH)
+                    .transactionIndex(0)
+                    .logIndex(-1)
+                    .chainId(SOLANA_CHAIN)
+                    .timestamp(BLOCK_TIMESTAMP)
+                    .nativeTransfer(true)
+                    .build();
+
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst())
+                    .usingRecursiveComparison()
+                    .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("parses multiple native transfers from a single block")
+        void parsesMultipleNativeTransfers() {
+            // given
+            var sender2 = "BPFLoaderUpgradeab1e11111111111111111111111";
+            var receiver2 = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+            var sig2 = "2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1iRgBj7rU3DLkV2xKHJWvNWh2JgDQjS4bnPC9RZ3aSMKY9g";
+
+            var block = aBlockWith(List.of(
+                    aSystemTransferTransaction(SENDER, RECEIVER, TX_SIGNATURE,
+                            5_000L, 2_000_000_000L, 1_000_000_000L),
+                    aSystemTransferTransaction(sender2, receiver2, sig2,
+                            5_000L, 500_000_000L, 500_000_000L)));
+
+            // when
+            var result = parser.parseNativeTransfers(block, SLOT);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).rawAmount()).isEqualTo("1000000000");
+            assertThat(result.get(1).rawAmount()).isEqualTo("500000000");
+        }
+
+        @Test
+        @DisplayName("skips failed transactions")
+        void skipsFailedTransactions() {
+            // given
+            var failedTx = aFailedSystemTransferTransaction(SENDER, RECEIVER, TX_SIGNATURE);
+            var block = aBlockWith(List.of(failedTx));
+
+            // when
+            var result = parser.parseNativeTransfers(block, SLOT);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("returns empty list for empty block")
+        void returnsEmptyForEmptyBlock() {
+            // given
+            var block = aBlockWith(List.of());
+
+            // when
+            var result = parser.parseNativeTransfers(block, SLOT);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("returns empty list for block with null transactions")
+        void returnsEmptyForNullTransactions() {
+            // given
+            var block = SolanaBlock.builder()
+                    .parentSlot(SLOT - 1)
+                    .blockhash(BLOCK_HASH)
+                    .previousBlockhash("prevhash")
+                    .blockTime(BLOCK_TIME)
+                    .transactions(null)
+                    .build();
+
+            // when
+            var result = parser.parseNativeTransfers(block, SLOT);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("skips non-SystemProgram instructions")
+        void skipsNonSystemProgramInstructions() {
+            // given
+            var tokenProgramInstruction = SolanaInstruction.builder()
+                    .programId("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
+                    .accounts(List.of(SENDER, RECEIVER))
+                    .data("3Bxs4ThwQbE4vyj5")
+                    .build();
+
+            var tx = SolanaTransaction.builder()
+                    .transaction(SolanaTransactionBody.builder()
+                            .message(SolanaTransactionMessage.builder()
+                                    .accountKeys(List.of(SENDER, RECEIVER,
+                                            "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"))
+                                    .instructions(List.of(tokenProgramInstruction))
+                                    .build())
+                            .signatures(List.of(TX_SIGNATURE))
+                            .build())
+                    .meta(SolanaTransactionMeta.builder()
+                            .err(null)
+                            .fee(5_000L)
+                            .preBalances(List.of(2_000_000_000L, 0L, 0L))
+                            .postBalances(List.of(1_000_000_000L, 1_000_000_000L, 0L))
+                            .preTokenBalances(List.of())
+                            .postTokenBalances(List.of())
+                            .build())
+                    .build();
+
+            var block = aBlockWith(List.of(tx));
+
+            // when
+            var result = parser.parseNativeTransfers(block, SLOT);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("handles small lamport amounts with correct precision")
+        void handlesSmallLamportAmounts() {
+            // given — 1 lamport transfer
+            var block = aBlockWith(List.of(
+                    aSystemTransferTransaction(SENDER, RECEIVER, TX_SIGNATURE,
+                            5_000L, 1_000_000_000L, 1L)));
+
+            // when
+            var result = parser.parseNativeTransfers(block, SLOT);
+
+            // then
+            var expected = Transfer.builder()
+                    .txHash(TX_SIGNATURE)
+                    .fromAddress(SENDER)
+                    .toAddress(RECEIVER)
+                    .rawAmount("1")
+                    .amount(new BigDecimal("0.000000001"))
+                    .decimals(SOL_DECIMALS)
+                    .tokenSymbol("SOL")
+                    .tokenContractAddress(null)
+                    .blockNumber(SLOT)
+                    .blockHash(BLOCK_HASH)
+                    .transactionIndex(0)
+                    .logIndex(-1)
+                    .chainId(SOLANA_CHAIN)
+                    .timestamp(BLOCK_TIMESTAMP)
+                    .nativeTransfer(true)
+                    .build();
+
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst())
+                    .usingRecursiveComparison()
+                    .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("handles large SOL transfer amount correctly")
+        void handlesLargeTransferAmount() {
+            // given — 1000 SOL = 1_000_000_000_000 lamports
+            var lamports = 1_000_000_000_000L;
+            var block = aBlockWith(List.of(
+                    aSystemTransferTransaction(SENDER, RECEIVER, TX_SIGNATURE,
+                            5_000L, 2_000_000_000_000L, lamports)));
+
+            // when
+            var result = parser.parseNativeTransfers(block, SLOT);
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst().rawAmount()).isEqualTo("1000000000000");
+            assertThat(result.getFirst().amount()).isEqualByComparingTo(new BigDecimal("1000"));
+        }
+
+        @Test
+        @DisplayName("sets correct transaction index for each transaction in block")
+        void setsCorrectTransactionIndex() {
+            // given
+            var sig2 = "2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1iRgBj7rU3DLkV2xKHJWvNWh2JgDQjS4bnPC9RZ3aSMKY9g";
+            var block = aBlockWith(List.of(
+                    aSystemTransferTransaction(SENDER, RECEIVER, TX_SIGNATURE,
+                            5_000L, 2_000_000_000L, 1_000_000_000L),
+                    aSystemTransferTransaction(SENDER, RECEIVER, sig2,
+                            5_000L, 2_000_000_000L, 500_000_000L)));
+
+            // when
+            var result = parser.parseNativeTransfers(block, SLOT);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).transactionIndex()).isZero();
+            assertThat(result.get(1).transactionIndex()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("skips instructions with insufficient accounts")
+        void skipsInstructionsWithInsufficientAccounts() {
+            // given — instruction with only 1 account (needs at least 2 for transfer)
+            var instruction = SolanaInstruction.builder()
+                    .programId(SYSTEM_PROGRAM_ID)
+                    .accounts(List.of(SENDER))
+                    .data("3Bxs4ThwQbE4vyj5")
+                    .build();
+
+            var tx = SolanaTransaction.builder()
+                    .transaction(SolanaTransactionBody.builder()
+                            .message(SolanaTransactionMessage.builder()
+                                    .accountKeys(List.of(SENDER, SYSTEM_PROGRAM_ID))
+                                    .instructions(List.of(instruction))
+                                    .build())
+                            .signatures(List.of(TX_SIGNATURE))
+                            .build())
+                    .meta(SolanaTransactionMeta.builder()
+                            .err(null)
+                            .fee(5_000L)
+                            .preBalances(List.of(2_000_000_000L, 0L))
+                            .postBalances(List.of(1_999_995_000L, 0L))
+                            .preTokenBalances(List.of())
+                            .postTokenBalances(List.of())
+                            .build())
+                    .build();
+
+            var block = aBlockWith(List.of(tx));
+
+            // when
+            var result = parser.parseNativeTransfers(block, SLOT);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("transfer properties")
+    class TransferProperties {
+
+        @Test
+        @DisplayName("sets nativeTransfer flag to true")
+        void setsNativeTransferFlag() {
+            // given
+            var block = aBlockWith(List.of(
+                    aSystemTransferTransaction(SENDER, RECEIVER, TX_SIGNATURE,
+                            5_000L, 2_000_000_000L, 1_000_000_000L)));
+
+            // when
+            var result = parser.parseNativeTransfers(block, SLOT);
+
+            // then
+            assertThat(result.getFirst().nativeTransfer()).isTrue();
+        }
+
+        @Test
+        @DisplayName("sets tokenContractAddress to null for native transfers")
+        void setsTokenContractAddressToNull() {
+            // given
+            var block = aBlockWith(List.of(
+                    aSystemTransferTransaction(SENDER, RECEIVER, TX_SIGNATURE,
+                            5_000L, 2_000_000_000L, 1_000_000_000L)));
+
+            // when
+            var result = parser.parseNativeTransfers(block, SLOT);
+
+            // then
+            assertThat(result.getFirst().tokenContractAddress()).isNull();
+        }
+
+        @Test
+        @DisplayName("sets logIndex to -1 for native transfers")
+        void setsLogIndexToNegativeOne() {
+            // given
+            var block = aBlockWith(List.of(
+                    aSystemTransferTransaction(SENDER, RECEIVER, TX_SIGNATURE,
+                            5_000L, 2_000_000_000L, 1_000_000_000L)));
+
+            // when
+            var result = parser.parseNativeTransfers(block, SLOT);
+
+            // then
+            assertThat(result.getFirst().logIndex()).isEqualTo(-1);
+        }
+
+        @Test
+        @DisplayName("uses SOLANA_CHAIN as chainId")
+        void usesSolanaChainId() {
+            // given
+            var block = aBlockWith(List.of(
+                    aSystemTransferTransaction(SENDER, RECEIVER, TX_SIGNATURE,
+                            5_000L, 2_000_000_000L, 1_000_000_000L)));
+
+            // when
+            var result = parser.parseNativeTransfers(block, SLOT);
+
+            // then
+            assertThat(result.getFirst().chainId()).isEqualTo(SOLANA_CHAIN);
+        }
+
+        @Test
+        @DisplayName("sets decimals to 9 for SOL")
+        void setsDecimalsToNine() {
+            // given
+            var block = aBlockWith(List.of(
+                    aSystemTransferTransaction(SENDER, RECEIVER, TX_SIGNATURE,
+                            5_000L, 2_000_000_000L, 1_000_000_000L)));
+
+            // when
+            var result = parser.parseNativeTransfers(block, SLOT);
+
+            // then
+            assertThat(result.getFirst().decimals()).isEqualTo(9);
+        }
+
+        @Test
+        @DisplayName("sets tokenSymbol to SOL")
+        void setsTokenSymbolToSol() {
+            // given
+            var block = aBlockWith(List.of(
+                    aSystemTransferTransaction(SENDER, RECEIVER, TX_SIGNATURE,
+                            5_000L, 2_000_000_000L, 1_000_000_000L)));
+
+            // when
+            var result = parser.parseNativeTransfers(block, SLOT);
+
+            // then
+            assertThat(result.getFirst().tokenSymbol()).isEqualTo("SOL");
+        }
+    }
+
+    // -- Test helpers (package-private ACL DTOs cannot go to testFixtures) --
+
+    private SolanaBlock aBlockWith(List<SolanaTransaction> transactions) {
+        return SolanaBlock.builder()
+                .parentSlot(SLOT - 1)
+                .blockhash(BLOCK_HASH)
+                .previousBlockhash("mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B")
+                .blockTime(BLOCK_TIME)
+                .transactions(transactions)
+                .build();
+    }
+
+    private SolanaTransaction aSystemTransferTransaction(String from, String to,
+                                                         String signature, long fee,
+                                                         long senderPreBalance,
+                                                         long transferLamports) {
+        var instruction = SolanaInstruction.builder()
+                .programId(SYSTEM_PROGRAM_ID)
+                .accounts(List.of(from, to))
+                .data("3Bxs4ThwQbE4vyj5")
+                .build();
+
+        var senderPostBalance = senderPreBalance - transferLamports - fee;
+        var receiverPreBalance = 0L;
+        var receiverPostBalance = transferLamports;
+
+        return SolanaTransaction.builder()
+                .transaction(SolanaTransactionBody.builder()
+                        .message(SolanaTransactionMessage.builder()
+                                .accountKeys(List.of(from, to, SYSTEM_PROGRAM_ID))
+                                .instructions(List.of(instruction))
+                                .build())
+                        .signatures(List.of(signature))
+                        .build())
+                .meta(SolanaTransactionMeta.builder()
+                        .err(null)
+                        .fee(fee)
+                        .preBalances(List.of(senderPreBalance, receiverPreBalance, 0L))
+                        .postBalances(List.of(senderPostBalance, receiverPostBalance, 0L))
+                        .preTokenBalances(List.of())
+                        .postTokenBalances(List.of())
+                        .build())
+                .build();
+    }
+
+    private SolanaTransaction aFailedSystemTransferTransaction(String from, String to,
+                                                               String signature) {
+        var instruction = SolanaInstruction.builder()
+                .programId(SYSTEM_PROGRAM_ID)
+                .accounts(List.of(from, to))
+                .data("3Bxs4ThwQbE4vyj5")
+                .build();
+
+        return SolanaTransaction.builder()
+                .transaction(SolanaTransactionBody.builder()
+                        .message(SolanaTransactionMessage.builder()
+                                .accountKeys(List.of(from, to, SYSTEM_PROGRAM_ID))
+                                .instructions(List.of(instruction))
+                                .build())
+                        .signatures(List.of(signature))
+                        .build())
+                .meta(SolanaTransactionMeta.builder()
+                        .err("InstructionError")
+                        .fee(5_000L)
+                        .preBalances(List.of(2_000_000_000L, 0L, 0L))
+                        .postBalances(List.of(1_999_995_000L, 0L, 0L))
+                        .preTokenBalances(List.of())
+                        .postTokenBalances(List.of())
+                        .build())
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SolanaNativeTransferParser` that detects `SystemProgram.Transfer` instructions in Solana blocks
- Extract native SOL transfers: from/to addresses from instruction accounts, lamport amounts from preBalances/postBalances diffs
- Convert lamports to SOL (9 decimals) with `rawAmount` + `amount` + `decimals` fields
- Skip failed transactions (`meta.err != null`) and instructions with insufficient accounts
- Package-private class following the ACL pattern established by the EVM parsers

## Implementation Details
- **SystemProgram ID**: `11111111111111111111111111111111` (32 ones)
- **Transfer detection**: Filter instructions by SystemProgram programId with at least 2 accounts
- **Amount computation**: `postBalances[toAccountIndex] - preBalances[toAccountIndex]` for the receiver
- **SOL properties**: decimals=9, tokenSymbol="SOL", nativeTransfer=true, logIndex=-1
- **Config gating**: Parser itself does not check the flag — that's the chain indexer adapter's responsibility (same pattern as EVM)

## Test Plan
- [x] Single native SOL transfer with correct amount conversion (1 SOL = 1,000,000,000 lamports)
- [x] Multiple native transfers in a single block
- [x] Failed transactions are skipped
- [x] Empty block returns empty list
- [x] Null transactions returns empty list
- [x] Non-SystemProgram instructions are skipped
- [x] Small lamport amounts (1 lamport = 0.000000001 SOL)
- [x] Large transfer amounts (1000 SOL)
- [x] Correct transaction index assignment
- [x] Instructions with insufficient accounts are skipped
- [x] Transfer properties: nativeTransfer=true, tokenContractAddress=null, logIndex=-1, chainId=SOLANA_CHAIN, decimals=9, tokenSymbol=SOL
- [x] All 16 tests passing
- [x] `./gradlew build` passes (compile + Spotless + all tests)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)