### PR TITLE
SBI-41: Add Bitcoin confirmation tracking

### DIFF
--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/bitcoin/BitcoinConfirmationTracker.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/bitcoin/BitcoinConfirmationTracker.java
@@ -1,0 +1,33 @@
+package com.stablebridge.indexer.infrastructure.chain.bitcoin;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class BitcoinConfirmationTracker {
+
+    private final BitcoinRpcClient rpcClient;
+    private final int minConfirmations;
+
+    BitcoinConfirmationTracker(BitcoinRpcClient rpcClient, int minConfirmations) {
+        this.rpcClient = rpcClient;
+        this.minConfirmations = minConfirmations;
+    }
+
+    long getLatestConfirmedBlockNumber() {
+        var blockCount = rpcClient.getBlockCount();
+        var confirmed = blockCount - minConfirmations;
+        log.debug("Bitcoin latest confirmed block: blockCount={}, minConfirmations={}, confirmed={}",
+                blockCount, minConfirmations, confirmed);
+        return Math.max(0, confirmed);
+    }
+
+    boolean hasEnoughConfirmations(long blockHeight) {
+        var blockCount = rpcClient.getBlockCount();
+        var confirmations = blockCount - blockHeight;
+        return confirmations >= minConfirmations;
+    }
+
+    int getMinConfirmations() {
+        return minConfirmations;
+    }
+}

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/bitcoin/BitcoinConfirmationTrackerTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/bitcoin/BitcoinConfirmationTrackerTest.java
@@ -1,0 +1,174 @@
+package com.stablebridge.indexer.infrastructure.chain.bitcoin;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BitcoinConfirmationTracker")
+class BitcoinConfirmationTrackerTest {
+
+    @Mock
+    private BitcoinRpcClient rpcClient;
+
+    @Nested
+    @DisplayName("getLatestConfirmedBlockNumber")
+    class GetLatestConfirmedBlockNumber {
+
+        @Test
+        @DisplayName("returns blockCount minus 6 confirmations (default)")
+        void returnsBlockCountMinusSixConfirmations() {
+            // given
+            given(rpcClient.getBlockCount()).willReturn(800000L);
+            var tracker = new BitcoinConfirmationTracker(rpcClient, 6);
+
+            // when
+            var result = tracker.getLatestConfirmedBlockNumber();
+
+            // then
+            assertThat(result).isEqualTo(799994L);
+        }
+
+        @Test
+        @DisplayName("returns blockCount minus 3 confirmations")
+        void returnsBlockCountMinusThreeConfirmations() {
+            // given
+            given(rpcClient.getBlockCount()).willReturn(800000L);
+            var tracker = new BitcoinConfirmationTracker(rpcClient, 3);
+
+            // when
+            var result = tracker.getLatestConfirmedBlockNumber();
+
+            // then
+            assertThat(result).isEqualTo(799997L);
+        }
+
+        @Test
+        @DisplayName("returns blockCount when 0 confirmations required")
+        void returnsBlockCountWhenZeroConfirmations() {
+            // given
+            given(rpcClient.getBlockCount()).willReturn(800000L);
+            var tracker = new BitcoinConfirmationTracker(rpcClient, 0);
+
+            // when
+            var result = tracker.getLatestConfirmedBlockNumber();
+
+            // then
+            assertThat(result).isEqualTo(800000L);
+        }
+
+        @Test
+        @DisplayName("returns zero when blockCount is less than minConfirmations")
+        void returnsZeroWhenBlockCountLessThanMinConfirmations() {
+            // given
+            given(rpcClient.getBlockCount()).willReturn(3L);
+            var tracker = new BitcoinConfirmationTracker(rpcClient, 6);
+
+            // when
+            var result = tracker.getLatestConfirmedBlockNumber();
+
+            // then
+            assertThat(result).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("calls getBlockCount on rpcClient")
+        void callsGetBlockCountOnRpcClient() {
+            // given
+            given(rpcClient.getBlockCount()).willReturn(800000L);
+            var tracker = new BitcoinConfirmationTracker(rpcClient, 6);
+
+            // when
+            tracker.getLatestConfirmedBlockNumber();
+
+            // then
+            then(rpcClient).should().getBlockCount();
+        }
+    }
+
+    @Nested
+    @DisplayName("hasEnoughConfirmations")
+    class HasEnoughConfirmations {
+
+        @Test
+        @DisplayName("returns true when block has exactly minConfirmations")
+        void returnsTrueWhenBlockHasExactlyMinConfirmations() {
+            // given
+            given(rpcClient.getBlockCount()).willReturn(800000L);
+            var tracker = new BitcoinConfirmationTracker(rpcClient, 6);
+
+            // when
+            var result = tracker.hasEnoughConfirmations(799994L);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("returns true when block has more than minConfirmations")
+        void returnsTrueWhenBlockHasMoreThanMinConfirmations() {
+            // given
+            given(rpcClient.getBlockCount()).willReturn(800000L);
+            var tracker = new BitcoinConfirmationTracker(rpcClient, 6);
+
+            // when
+            var result = tracker.hasEnoughConfirmations(799000L);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("returns false when block has fewer than minConfirmations")
+        void returnsFalseWhenBlockHasFewerThanMinConfirmations() {
+            // given
+            given(rpcClient.getBlockCount()).willReturn(800000L);
+            var tracker = new BitcoinConfirmationTracker(rpcClient, 6);
+
+            // when
+            var result = tracker.hasEnoughConfirmations(799998L);
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("returns false when block is the latest block with non-zero confirmations required")
+        void returnsFalseWhenBlockIsLatestWithConfirmationsRequired() {
+            // given
+            given(rpcClient.getBlockCount()).willReturn(800000L);
+            var tracker = new BitcoinConfirmationTracker(rpcClient, 6);
+
+            // when
+            var result = tracker.hasEnoughConfirmations(800000L);
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("getMinConfirmations")
+    class GetMinConfirmations {
+
+        @Test
+        @DisplayName("returns configured minConfirmations value")
+        void returnsConfiguredMinConfirmationsValue() {
+            // given
+            var tracker = new BitcoinConfirmationTracker(rpcClient, 6);
+
+            // when
+            var result = tracker.getMinConfirmations();
+
+            // then
+            assertThat(result).isEqualTo(6);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `BitcoinConfirmationTracker` that encapsulates confirmation-based finality logic for Bitcoin (ADR Decision 8)
- Computes latest confirmed block number as `getblockcount() - minConfirmations` (default 6 confirmations)
- Provides `hasEnoughConfirmations(blockHeight)` check for individual block validation
- Handles edge case where chain is very young (blockCount < minConfirmations) by returning 0

## Test plan
- [x] Unit test: 6 confirmations (default) — blockCount=800000, confirmed=799994
- [x] Unit test: 3 confirmations — blockCount=800000, confirmed=799997
- [x] Unit test: 0 confirmations — blockCount=800000, confirmed=800000
- [x] Unit test: Edge case — blockCount=3, minConfirmations=6 returns 0 (not negative)
- [x] Unit test: hasEnoughConfirmations returns true (exact and more than minConfirmations)
- [x] Unit test: hasEnoughConfirmations returns false (fewer than minConfirmations)
- [x] Unit test: Verify RPC client interaction
- [x] `./gradlew build` passes (compile + Spotless + all tests)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)