### PR TITLE
SBI-38: Add Solana chain factory registration

### DIFF
--- a/stablebridge-indexer/src/main/resources/application.yml
+++ b/stablebridge-indexer/src/main/resources/application.yml
@@ -147,3 +147,24 @@ indexer:
         - address: "0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42"
           symbol: EURC
           decimals: 6
+
+    solana_mainnet:
+      enabled: false
+      type: solana
+      confirmation-strategy: finalized
+      index-native-transfers: false
+      native-decimals: 9
+      start-block: 0
+      poll-interval: 400ms
+      batch-size: 10
+      rpc:
+        urls:
+          - ${SOLANA_RPC_URL:https://api.mainnet-beta.solana.com}
+        timeout: 10s
+      token-contracts:
+        - address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+          symbol: USDC
+          decimals: 6
+        - address: "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"
+          symbol: USDT
+          decimals: 6


### PR DESCRIPTION
## Summary
- Add `solana_mainnet` chain configuration entry to `application.yml` (disabled by default)
- Includes USDC and USDT SPL token contract addresses on Solana mainnet
- Factory, auto-configuration, and integration tests were already implemented in SBI-37 (PR #94)

## Test plan
- [x] `./gradlew build` passes (compile + Spotless + all tests)
- [x] Existing `ChainAutoConfigurationTest` covers Solana factory creation
- [x] Chain disabled by default — no runtime impact

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)