### PR TITLE
SBI-43: Add Bitcoin chain factory registration

### DIFF
--- a/stablebridge-indexer/src/main/resources/application.yml
+++ b/stablebridge-indexer/src/main/resources/application.yml
@@ -168,3 +168,20 @@ indexer:
         - address: "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"
           symbol: USDT
           decimals: 6
+
+    bitcoin_mainnet:
+      enabled: false
+      type: bitcoin
+      confirmation-strategy: confirmations
+      min-confirmations: 6
+      index-native-transfers: true
+      native-decimals: 8
+      start-block: 0
+      poll-interval: 60s
+      batch-size: 5
+      rpc:
+        urls:
+          - ${BITCOIN_RPC_URL:http://localhost:8332}
+        timeout: 30s
+        username: ${BITCOIN_RPC_USERNAME:bitcoin}
+        password: ${BITCOIN_RPC_PASSWORD:bitcoin}


### PR DESCRIPTION
## Summary
- Add `bitcoin_mainnet` chain configuration entry to `application.yml` (disabled by default)
- Includes Basic Auth RPC credentials (`username`/`password`) via env vars
- Uses 6-block confirmation strategy (Bitcoin standard finality)
- Factory, auto-configuration, and integration tests were already implemented in SBI-42 (PR #95)

## Test plan
- [x] `./gradlew build` passes (compile + Spotless + all tests)
- [x] Existing `ChainAutoConfigurationTest` covers Bitcoin factory creation
- [x] Chain disabled by default — no runtime impact

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bitcoin mainnet network support to the indexer for blockchain data indexing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->