### PR TITLE
Add Newman/Postman API tests and update README with Make commands

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -1,0 +1,116 @@
+name: API Tests (Newman)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - 'postman/**'
+      - 'stablebridge-indexer/src/main/java/**/controller/**'
+      - 'stablebridge-indexer/src/main/java/**/security/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'postman/**'
+      - 'stablebridge-indexer/src/main/java/**/controller/**'
+      - 'stablebridge-indexer/src/main/java/**/security/**'
+
+permissions:
+  contents: read
+
+jobs:
+  api-test:
+    name: Newman API Tests
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: indexer
+          POSTGRES_USER: indexer
+          POSTGRES_PASSWORD: indexer
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis/redis-stack:latest
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redpanda:
+        image: redpandadata/redpanda:v24.3.1
+        ports:
+          - 19092:19092
+        options: >-
+          --health-cmd "rpk cluster health --api-urls localhost:9644"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25-ea'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Build application
+        run: ./gradlew :stablebridge-indexer:build -x test -x integrationTest -x spotlessCheck
+
+      - name: Start application
+        run: |
+          ./gradlew :stablebridge-indexer:bootRun &
+          echo "Waiting for application to start..."
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:8081/actuator/health > /dev/null 2>&1; then
+              echo "Application is ready"
+              break
+            fi
+            sleep 2
+          done
+        env:
+          SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/indexer
+          SPRING_DATASOURCE_USERNAME: indexer
+          SPRING_DATASOURCE_PASSWORD: indexer
+          SPRING_DATA_REDIS_HOST: localhost
+          SPRING_DATA_REDIS_PORT: 6379
+          KAFKA_BOOTSTRAP_SERVERS: localhost:19092
+          INDEXER_API_KEY: test-api-key-ci
+
+      - name: Install Newman
+        run: npm install -g newman newman-reporter-htmlextra
+
+      - name: Run Newman API tests
+        run: |
+          newman run postman/stablebridge-indexer.postman_collection.json \
+            -e postman/local.postman_environment.json \
+            --env-var "apiKey=test-api-key-ci" \
+            --reporters cli,junit,htmlextra \
+            --reporter-junit-export build/reports/newman/results.xml \
+            --reporter-htmlextra-export build/reports/newman/report.html
+
+      - name: Upload Newman reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: newman-reports
+          path: build/reports/newman/
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       postgres:
         image: postgres:16-alpine
         env:
-          POSTGRES_DB: multichain_indexer
+          POSTGRES_DB: indexer
           POSTGRES_USER: indexer
           POSTGRES_PASSWORD: indexer
         ports:
@@ -105,7 +105,7 @@ jobs:
       - name: Run integration tests
         run: ./gradlew integrationTest
         env:
-          SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/multichain_indexer
+          SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/indexer
           SPRING_DATASOURCE_USERNAME: indexer
           SPRING_DATASOURCE_PASSWORD: indexer
           SPRING_DATA_REDIS_HOST: localhost

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help build test integration-test clean run run-testnet \
        infra-up infra-down infra-status infra-logs \
-       smoke-test register-wallet check-status \
+       smoke-test api-test register-wallet check-status \
        docker-build terraform-init terraform-up terraform-down
 
 # ---------------------------------------------------------------------------
@@ -78,6 +78,17 @@ docker-build: ## Build production Docker image via Jib
 # ---------------------------------------------------------------------------
 smoke-test: ## Run smoke test against running indexer
 	./scripts/smoke-test.sh
+
+api-test: ## Run Newman/Postman API tests against running indexer
+	newman run postman/stablebridge-indexer.postman_collection.json \
+		-e postman/local.postman_environment.json \
+		--reporters cli,junit \
+		--reporter-junit-export build/reports/newman/results.xml
+
+api-test-testnet: ## Run Newman API tests against testnet instance
+	newman run postman/stablebridge-indexer.postman_collection.json \
+		-e postman/testnet.postman_environment.json \
+		--reporters cli
 
 register-wallet: ## Register a test wallet (usage: make register-wallet ADDR=0x... TYPE=EVM)
 	@curl -s -X POST http://localhost:8080/api/v1/wallets \

--- a/README.md
+++ b/README.md
@@ -365,12 +365,78 @@ All logs use structured JSON format with 10 enriched MDC fields for audit trails
 
 ---
 
+## :hammer_and_wrench: Make Commands
+
+A `Makefile` wraps all common operations:
+
+### Build & Test
+
+```bash
+make build              # Compile + Spotless + all tests
+make test               # Unit tests only
+make integration-test   # Integration tests (requires Docker services)
+make clean              # Clean build artifacts
+```
+
+### Run
+
+```bash
+make run                # Run with default profile (mainnet)
+make run-testnet        # Run with testnet profile (Sepolia, Base Sepolia, Solana Devnet)
+```
+
+### Infrastructure
+
+```bash
+make infra-up           # Start PostgreSQL, Redis, Redpanda, Prometheus, Grafana
+make infra-down         # Stop all containers
+make infra-clean        # Stop + delete all volumes
+make infra-status       # Show container status
+make infra-logs         # Tail container logs
+```
+
+### Terraform (alternative to Docker Compose)
+
+```bash
+make terraform-init     # Initialize Terraform Docker provider
+make terraform-up       # Provision all containers via Terraform
+make terraform-down     # Destroy Terraform-managed containers
+```
+
+### Inspection
+
+```bash
+make check-health       # Actuator health check
+make check-status       # All chain statuses
+make check-redis        # Block progress + Bloom filter info
+make check-kafka        # List Kafka topics
+```
+
+### Testing & Smoke
+
+```bash
+make smoke-test         # Run smoke test script against running indexer
+make api-test           # Run Newman/Postman API tests
+make register-wallet ADDR=0x... TYPE=EVM   # Register a test wallet
+```
+
+### Docker Image
+
+```bash
+make docker-build       # Build production image via Jib (eclipse-temurin:25-jre)
+```
+
+Run `make help` to see all available targets.
+
+---
+
 ## :whale: Docker
 
 ### Development Infrastructure
 
 ```bash
-docker compose up -d
+make infra-up
+# or: docker compose up -d
 ```
 
 | Service | Port | Description |
@@ -384,10 +450,9 @@ docker compose up -d
 
 ### Production Image
 
-Build a production Docker image with Jib (no Docker daemon required):
-
 ```bash
-./gradlew :stablebridge-indexer:jibDockerBuild
+make docker-build
+# or: ./gradlew :stablebridge-indexer:jibDockerBuild
 ```
 
 Image: `stablebridge/indexer` based on `eclipse-temurin:25-jre`.
@@ -399,15 +464,32 @@ Image: `stablebridge/indexer` based on `eclipse-temurin:25-jre`.
 The project has **414 tests** across **44 test files**, organized by category:
 
 ```bash
-# Run all tests
-./gradlew test
-
-# Run integration tests (requires Docker services)
-./gradlew integrationTest
-
-# Run all checks (Spotless + compile + tests)
-./gradlew build
+make build              # Full build (Spotless + compile + all tests)
+make test               # Unit tests only
+make integration-test   # Integration tests (requires Docker services)
 ```
+
+### API Tests (Newman/Postman)
+
+A Postman collection at `postman/` covers all API endpoints with assertions:
+
+```bash
+# Install Newman
+npm install -g newman
+
+# Run against local instance
+make api-test
+# or: newman run postman/stablebridge-indexer.postman_collection.json \
+#       -e postman/local.postman_environment.json
+
+# Run against testnet instance
+newman run postman/stablebridge-indexer.postman_collection.json \
+  -e postman/testnet.postman_environment.json
+```
+
+**Test coverage**: Authentication (401 for missing/wrong key), wallet CRUD (register, batch, list, delete, duplicate handling), chain status (all chains, single chain, unknown chain 404), Bloom filter status, Prometheus metrics, health check.
+
+You can also import `postman/stablebridge-indexer.postman_collection.json` directly into Postman for interactive testing.
 
 ### Testing Stack
 

--- a/postman/local.postman_environment.json
+++ b/postman/local.postman_environment.json
@@ -1,0 +1,9 @@
+{
+  "id": "local-env",
+  "name": "Local",
+  "values": [
+    { "key": "baseUrl", "value": "http://localhost:8080", "enabled": true },
+    { "key": "mgmtUrl", "value": "http://localhost:8081", "enabled": true },
+    { "key": "apiKey", "value": "change-me", "enabled": true }
+  ]
+}

--- a/postman/stablebridge-indexer.postman_collection.json
+++ b/postman/stablebridge-indexer.postman_collection.json
@@ -1,0 +1,648 @@
+{
+  "info": {
+    "name": "StableBridge Indexer",
+    "description": "API test collection for StableBridge Indexer.\n\nCovers wallet management, status, bloom filter, and authentication.\n\nRun with Newman:\n```\nnewman run postman/stablebridge-indexer.postman_collection.json \\\n  -e postman/local.postman_environment.json\n```",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    { "key": "baseUrl", "value": "http://localhost:8080" },
+    { "key": "mgmtUrl", "value": "http://localhost:8081" },
+    { "key": "apiKey", "value": "change-me" },
+    { "key": "testAddress", "value": "" },
+    { "key": "testAddressBatch1", "value": "" },
+    { "key": "testAddressBatch2", "value": "" }
+  ],
+  "auth": {
+    "type": "apikey",
+    "apikey": [
+      { "key": "key", "value": "X-API-Key", "type": "string" },
+      { "key": "value", "value": "{{apiKey}}", "type": "string" },
+      { "key": "in", "value": "header", "type": "string" }
+    ]
+  },
+  "item": [
+    {
+      "name": "Health & Actuator",
+      "item": [
+        {
+          "name": "Health Check",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Health status is UP', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body.status).to.eql('UP');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "GET",
+            "url": "{{mgmtUrl}}/actuator/health"
+          }
+        },
+        {
+          "name": "Prometheus Metrics",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Contains indexer metrics', () => {",
+                  "  pm.expect(pm.response.text()).to.include('indexer_');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "GET",
+            "url": "{{mgmtUrl}}/actuator/prometheus"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Authentication",
+      "item": [
+        {
+          "name": "No API Key - 401",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 401', () => pm.response.to.have.status(401));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "GET",
+            "url": "{{baseUrl}}/api/v1/status"
+          }
+        },
+        {
+          "name": "Wrong API Key - 401",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 401', () => pm.response.to.have.status(401));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "GET",
+            "url": "{{baseUrl}}/api/v1/status",
+            "header": [
+              { "key": "X-API-Key", "value": "wrong-key-12345" }
+            ]
+          }
+        },
+        {
+          "name": "Valid API Key - 200",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 200', () => pm.response.to.have.status(200));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/api/v1/status"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Chain Status",
+      "item": [
+        {
+          "name": "Get All Chain Statuses",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Response is array', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.be.an('array');",
+                  "});",
+                  "pm.test('Each chain has required fields', () => {",
+                  "  const body = pm.response.json();",
+                  "  body.forEach(chain => {",
+                  "    pm.expect(chain).to.have.property('chainId');",
+                  "    pm.expect(chain).to.have.property('networkType');",
+                  "    pm.expect(chain).to.have.property('workerState');",
+                  "    pm.expect(chain).to.have.property('enabled');",
+                  "  });",
+                  "});",
+                  "",
+                  "// Save first chain name for single chain status test",
+                  "const body = pm.response.json();",
+                  "if (body.length > 0) {",
+                  "  pm.collectionVariables.set('firstChainId', body[0].chainId);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/api/v1/status"
+          }
+        },
+        {
+          "name": "Get Single Chain Status",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Response has chain fields', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('chainId');",
+                  "  pm.expect(body).to.have.property('workerState');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/api/v1/status/{{firstChainId}}"
+          }
+        },
+        {
+          "name": "Get Unknown Chain - 404",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 404', () => pm.response.to.have.status(404));",
+                  "pm.test('Error response has message', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('message');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/api/v1/status/nonexistent_chain"
+          }
+        },
+        {
+          "name": "Get Bloom Status",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Response has bloom fields', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('backend');",
+                  "  pm.expect(body).to.have.property('expectedInsertions');",
+                  "  pm.expect(body).to.have.property('errorRate');",
+                  "  pm.expect(body).to.have.property('networkTypes');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/api/v1/status/bloom"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Wallet Management",
+      "item": [
+        {
+          "name": "Register EVM Wallet",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "// Generate a unique test address",
+                  "const hex = Array.from({length: 40}, () => Math.floor(Math.random() * 16).toString(16)).join('');",
+                  "const addr = '0x' + hex;",
+                  "pm.collectionVariables.set('testAddress', addr);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 201', () => pm.response.to.have.status(201));",
+                  "pm.test('Response has wallet fields', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('id');",
+                  "  pm.expect(body).to.have.property('address');",
+                  "  pm.expect(body).to.have.property('networkType');",
+                  "  pm.expect(body.networkType).to.eql('EVM');",
+                  "  pm.expect(body).to.have.property('createdAt');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/api/v1/wallets",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"address\": \"{{testAddress}}\",\n  \"networkType\": \"EVM\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Register Duplicate Wallet - 409",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 409', () => pm.response.to.have.status(409));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/api/v1/wallets",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"address\": \"{{testAddress}}\",\n  \"networkType\": \"EVM\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Register Wallet - Missing Address - 400",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 400', () => pm.response.to.have.status(400));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/api/v1/wallets",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"address\": \"\",\n  \"networkType\": \"EVM\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Batch Register Wallets",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "const hex1 = Array.from({length: 40}, () => Math.floor(Math.random() * 16).toString(16)).join('');",
+                  "const hex2 = Array.from({length: 40}, () => Math.floor(Math.random() * 16).toString(16)).join('');",
+                  "pm.collectionVariables.set('testAddressBatch1', '0x' + hex1);",
+                  "pm.collectionVariables.set('testAddressBatch2', '0x' + hex2);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 201', () => pm.response.to.have.status(201));",
+                  "pm.test('Response is array of 2', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.be.an('array');",
+                  "  pm.expect(body).to.have.lengthOf(2);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/api/v1/wallets/batch",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\"address\": \"{{testAddressBatch1}}\", \"networkType\": \"EVM\"},\n  {\"address\": \"{{testAddressBatch2}}\", \"networkType\": \"EVM\"}\n]"
+            }
+          }
+        },
+        {
+          "name": "List EVM Wallets",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Response is array', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.be.an('array');",
+                  "});",
+                  "pm.test('Contains at least 3 wallets (1 single + 2 batch)', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body.length).to.be.at.least(3);",
+                  "});",
+                  "pm.test('All wallets are EVM type', () => {",
+                  "  const body = pm.response.json();",
+                  "  body.forEach(w => pm.expect(w.networkType).to.eql('EVM'));",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/wallets?networkType=EVM",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "wallets"],
+              "query": [{ "key": "networkType", "value": "EVM" }]
+            }
+          }
+        },
+        {
+          "name": "Rebuild Bloom Filter",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 200', () => pm.response.to.have.status(200));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/api/v1/wallets/bloom/rebuild"
+          }
+        },
+        {
+          "name": "Delete Wallet",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 204', () => pm.response.to.have.status(204));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/wallets/{{testAddress}}?networkType=EVM",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "wallets", "{{testAddress}}"],
+              "query": [{ "key": "networkType", "value": "EVM" }]
+            }
+          }
+        },
+        {
+          "name": "Delete Batch Wallet 1",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 204', () => pm.response.to.have.status(204));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/wallets/{{testAddressBatch1}}?networkType=EVM",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "wallets", "{{testAddressBatch1}}"],
+              "query": [{ "key": "networkType", "value": "EVM" }]
+            }
+          }
+        },
+        {
+          "name": "Delete Batch Wallet 2",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 204', () => pm.response.to.have.status(204));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/wallets/{{testAddressBatch2}}?networkType=EVM",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "wallets", "{{testAddressBatch2}}"],
+              "query": [{ "key": "networkType", "value": "EVM" }]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Solana Wallet",
+      "item": [
+        {
+          "name": "Register Solana Wallet",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "// Generate a base58-like test address",
+                  "const chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';",
+                  "const addr = Array.from({length: 44}, () => chars[Math.floor(Math.random() * chars.length)]).join('');",
+                  "pm.collectionVariables.set('solanaTestAddress', addr);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 201', () => pm.response.to.have.status(201));",
+                  "pm.test('Network type is SOLANA', () => {",
+                  "  pm.expect(pm.response.json().networkType).to.eql('SOLANA');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/api/v1/wallets",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"address\": \"{{solanaTestAddress}}\",\n  \"networkType\": \"SOLANA\"\n}"
+            }
+          }
+        },
+        {
+          "name": "List Solana Wallets",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Contains Solana wallets', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.be.an('array');",
+                  "  pm.expect(body.length).to.be.at.least(1);",
+                  "  body.forEach(w => pm.expect(w.networkType).to.eql('SOLANA'));",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/wallets?networkType=SOLANA",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "wallets"],
+              "query": [{ "key": "networkType", "value": "SOLANA" }]
+            }
+          }
+        },
+        {
+          "name": "Delete Solana Wallet",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 204', () => pm.response.to.have.status(204));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/wallets/{{solanaTestAddress}}?networkType=SOLANA",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "wallets", "{{solanaTestAddress}}"],
+              "query": [{ "key": "networkType", "value": "SOLANA" }]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Bitcoin Wallet",
+      "item": [
+        {
+          "name": "Register Bitcoin Wallet",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "const chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';",
+                  "const addr = 'tb1q' + Array.from({length: 38}, () => chars[Math.floor(Math.random() * chars.length)]).join('');",
+                  "pm.collectionVariables.set('bitcoinTestAddress', addr);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 201', () => pm.response.to.have.status(201));",
+                  "pm.test('Network type is BITCOIN', () => {",
+                  "  pm.expect(pm.response.json().networkType).to.eql('BITCOIN');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/api/v1/wallets",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"address\": \"{{bitcoinTestAddress}}\",\n  \"networkType\": \"BITCOIN\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Delete Bitcoin Wallet",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 204', () => pm.response.to.have.status(204));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/wallets/{{bitcoinTestAddress}}?networkType=BITCOIN",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "wallets", "{{bitcoinTestAddress}}"],
+              "query": [{ "key": "networkType", "value": "BITCOIN" }]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/postman/testnet.postman_environment.json
+++ b/postman/testnet.postman_environment.json
@@ -1,0 +1,9 @@
+{
+  "id": "testnet-env",
+  "name": "Testnet",
+  "values": [
+    { "key": "baseUrl", "value": "http://localhost:8080", "enabled": true },
+    { "key": "mgmtUrl", "value": "http://localhost:8081", "enabled": true },
+    { "key": "apiKey", "value": "test-api-key-12345", "enabled": true }
+  ]
+}


### PR DESCRIPTION
## Summary
- **Postman collection** (`postman/`) with 20 test assertions covering auth, wallet CRUD, chain status, bloom, health, and Prometheus metrics
- **Newman CI workflow** (`.github/workflows/api-test.yml`) — starts app with services, runs Newman, uploads HTML/JUnit reports
- **Fix CI workflow** DB name (`multichain_indexer` → `indexer`)
- **Makefile** — add `api-test` and `api-test-testnet` targets
- **README** — add "Make Commands" section and Newman/Postman API testing docs

## Postman Test Coverage
| Folder | Tests |
|--------|-------|
| Health & Actuator | Health UP, Prometheus metrics contain `indexer_` |
| Authentication | Missing key (401), wrong key (401), valid key (200) |
| Chain Status | All chains, single chain, unknown chain (404), bloom status |
| Wallet Management | Register (201), duplicate (409), missing address (400), batch (201), list, rebuild bloom, delete (204) |
| Solana Wallet | Register SOLANA (201), list, delete |
| Bitcoin Wallet | Register BITCOIN (201), delete |

## Test plan
- [ ] `make infra-up` → `make run` → `make api-test` passes all 20 assertions
- [ ] `make smoke-test` passes
- [ ] GitHub Actions `api-test.yml` workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)