### PR TITLE
SBI-52: add TRON, APTOS, SUI, COSMOS, TON to NetworkType/ChainId enums

### DIFF
--- a/stablebridge-indexer-api/src/main/java/com/stablebridge/indexer/api/NetworkType.java
+++ b/stablebridge-indexer-api/src/main/java/com/stablebridge/indexer/api/NetworkType.java
@@ -3,5 +3,10 @@ package com.stablebridge.indexer.api;
 public enum NetworkType {
     EVM,
     SOLANA,
-    BITCOIN
+    BITCOIN,
+    TRON,
+    APTOS,
+    SUI,
+    COSMOS,
+    TON
 }

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/domain/model/ChainId.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/domain/model/ChainId.java
@@ -1,8 +1,13 @@
 package com.stablebridge.indexer.domain.model;
 
+import static com.stablebridge.indexer.domain.model.NetworkType.APTOS;
 import static com.stablebridge.indexer.domain.model.NetworkType.BITCOIN;
+import static com.stablebridge.indexer.domain.model.NetworkType.COSMOS;
 import static com.stablebridge.indexer.domain.model.NetworkType.EVM;
 import static com.stablebridge.indexer.domain.model.NetworkType.SOLANA;
+import static com.stablebridge.indexer.domain.model.NetworkType.SUI;
+import static com.stablebridge.indexer.domain.model.NetworkType.TON;
+import static com.stablebridge.indexer.domain.model.NetworkType.TRON;
 
 public enum ChainId {
 
@@ -18,7 +23,18 @@ public enum ChainId {
     SOLANA_CHAIN(SOLANA),
     SOLANA_DEVNET(SOLANA),
     BITCOIN_CHAIN(BITCOIN),
-    BITCOIN_TESTNET(BITCOIN);
+    BITCOIN_TESTNET(BITCOIN),
+    TRON_CHAIN(TRON),
+    TRON_SHASTA(TRON),
+    APTOS_CHAIN(APTOS),
+    APTOS_DEVNET(APTOS),
+    SUI_CHAIN(SUI),
+    SUI_DEVNET(SUI),
+    NOBLE(COSMOS),
+    OSMOSIS(COSMOS),
+    COSMOS_HUB(COSMOS),
+    TON_CHAIN(TON),
+    TON_TESTNET(TON);
 
     private final NetworkType networkType;
 

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/domain/model/NetworkType.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/domain/model/NetworkType.java
@@ -3,5 +3,10 @@ package com.stablebridge.indexer.domain.model;
 public enum NetworkType {
     EVM,
     SOLANA,
-    BITCOIN
+    BITCOIN,
+    TRON,
+    APTOS,
+    SUI,
+    COSMOS,
+    TON
 }

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/bloom/GuavaBloomAddressFilter.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/bloom/GuavaBloomAddressFilter.java
@@ -84,7 +84,10 @@ public class GuavaBloomAddressFilter implements AddressFilter {
     }
 
     private static String normalizeAddress(String address, NetworkType networkType) {
-        return networkType == NetworkType.EVM ? address.toLowerCase() : address;
+        return switch (networkType) {
+            case EVM, TRON, APTOS, SUI, COSMOS, TON -> address.toLowerCase();
+            case SOLANA, BITCOIN -> address;
+        };
     }
 
     @SuppressWarnings("UnstableApiUsage")

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/bloom/RedisBloomAddressFilter.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/bloom/RedisBloomAddressFilter.java
@@ -117,7 +117,10 @@ public class RedisBloomAddressFilter implements AddressFilter {
     }
 
     private static String normalizeAddress(String address, NetworkType networkType) {
-        return networkType == NetworkType.EVM ? address.toLowerCase() : address;
+        return switch (networkType) {
+            case EVM, TRON, APTOS, SUI, COSMOS, TON -> address.toLowerCase();
+            case SOLANA, BITCOIN -> address;
+        };
     }
 
     private String bloomKey(NetworkType networkType) {

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/application/config/BloomFilterHealthIndicatorTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/application/config/BloomFilterHealthIndicatorTest.java
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static com.stablebridge.indexer.application.config.BloomFilterHealthIndicator.BLOOM_SIZE_METRIC;
 import static com.stablebridge.indexer.application.config.BloomFilterHealthIndicator.PROBE_ADDRESS;
-import static com.stablebridge.indexer.domain.model.NetworkType.BITCOIN;
 import static com.stablebridge.indexer.domain.model.NetworkType.EVM;
 import static com.stablebridge.indexer.domain.model.NetworkType.SOLANA;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,19 +49,14 @@ class BloomFilterHealthIndicatorTest {
             given(addressFilter.mightContain(PROBE_ADDRESS, networkType)).willReturn(false);
         }
 
-        registerBloomSizeGauge(EVM.name(), 150);
-        registerBloomSizeGauge(SOLANA.name(), 50);
-        registerBloomSizeGauge(BITCOIN.name(), 0);
+        var gaugeSizes = Map.of(EVM, 150L, SOLANA, 50L);
+        gaugeSizes.forEach((nt, size) -> registerBloomSizeGauge(nt.name(), size));
 
         var expectedFilters = new LinkedHashMap<String, Map<String, Object>>();
-        expectedFilters.put("EVM", filterDetail(true, 150L));
-        expectedFilters.put("SOLANA", filterDetail(true, 50L));
-        expectedFilters.put("BITCOIN", filterDetail(true, 0L));
-        expectedFilters.put("TRON", filterDetail(true, 0L));
-        expectedFilters.put("APTOS", filterDetail(true, 0L));
-        expectedFilters.put("SUI", filterDetail(true, 0L));
-        expectedFilters.put("COSMOS", filterDetail(true, 0L));
-        expectedFilters.put("TON", filterDetail(true, 0L));
+        for (var networkType : NetworkType.values()) {
+            var size = gaugeSizes.getOrDefault(networkType, 0L);
+            expectedFilters.put(networkType.name(), filterDetail(true, size));
+        }
 
         var expected = Health.up()
                 .withDetail("filters", expectedFilters)
@@ -79,24 +73,25 @@ class BloomFilterHealthIndicatorTest {
     @DisplayName("reports DOWN when a bloom filter is unavailable")
     void reportsDownWhenFilterUnavailable() {
         // given
-        given(addressFilter.mightContain(PROBE_ADDRESS, EVM)).willReturn(false);
-        given(addressFilter.mightContain(PROBE_ADDRESS, SOLANA))
-                .willThrow(new RuntimeException("Redis connection refused"));
-        given(addressFilter.mightContain(PROBE_ADDRESS, BITCOIN)).willReturn(false);
-        stubRemainingNetworkTypesAsAvailable(EVM, SOLANA, BITCOIN);
+        var unavailable = Set.of(SOLANA);
+        for (var networkType : NetworkType.values()) {
+            if (unavailable.contains(networkType)) {
+                given(addressFilter.mightContain(PROBE_ADDRESS, networkType))
+                        .willThrow(new RuntimeException("Redis connection refused"));
+            } else {
+                given(addressFilter.mightContain(PROBE_ADDRESS, networkType)).willReturn(false);
+            }
+        }
 
-        registerBloomSizeGauge(EVM.name(), 100);
-        registerBloomSizeGauge(BITCOIN.name(), 0);
+        var gaugeSizes = Map.of(EVM, 100L);
+        gaugeSizes.forEach((nt, size) -> registerBloomSizeGauge(nt.name(), size));
 
         var expectedFilters = new LinkedHashMap<String, Map<String, Object>>();
-        expectedFilters.put("EVM", filterDetail(true, 100L));
-        expectedFilters.put("SOLANA", filterDetail(false, 0L));
-        expectedFilters.put("BITCOIN", filterDetail(true, 0L));
-        expectedFilters.put("TRON", filterDetail(true, 0L));
-        expectedFilters.put("APTOS", filterDetail(true, 0L));
-        expectedFilters.put("SUI", filterDetail(true, 0L));
-        expectedFilters.put("COSMOS", filterDetail(true, 0L));
-        expectedFilters.put("TON", filterDetail(true, 0L));
+        for (var networkType : NetworkType.values()) {
+            var available = !unavailable.contains(networkType);
+            var size = available ? gaugeSizes.getOrDefault(networkType, 0L) : 0L;
+            expectedFilters.put(networkType.name(), filterDetail(available, size));
+        }
 
         var expected = Health.down()
                 .withDetail("filters", expectedFilters)
@@ -163,15 +158,6 @@ class BloomFilterHealthIndicatorTest {
         Gauge.builder(BLOOM_SIZE_METRIC, counter, AtomicLong::get)
                 .tag("networkType", networkType)
                 .register(meterRegistry);
-    }
-
-    private void stubRemainingNetworkTypesAsAvailable(NetworkType... alreadyStubbed) {
-        var stubbedSet = Set.of(alreadyStubbed);
-        for (var networkType : NetworkType.values()) {
-            if (!stubbedSet.contains(networkType)) {
-                given(addressFilter.mightContain(PROBE_ADDRESS, networkType)).willReturn(false);
-            }
-        }
     }
 
     private static Map<String, Object> filterDetail(boolean available, long approximateEntryCount) {

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/application/config/BloomFilterHealthIndicatorTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/application/config/BloomFilterHealthIndicatorTest.java
@@ -1,5 +1,6 @@
 package com.stablebridge.indexer.application.config;
 
+import com.stablebridge.indexer.domain.model.NetworkType;
 import com.stablebridge.indexer.domain.port.AddressFilter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -13,6 +14,7 @@ import org.springframework.boot.health.contributor.Health;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.stablebridge.indexer.application.config.BloomFilterHealthIndicator.BLOOM_SIZE_METRIC;
@@ -44,19 +46,26 @@ class BloomFilterHealthIndicatorTest {
     @DisplayName("reports UP when all bloom filters are available")
     void reportsUpWhenAllFiltersAvailable() {
         // given
-        given(addressFilter.mightContain(PROBE_ADDRESS, EVM)).willReturn(false);
-        given(addressFilter.mightContain(PROBE_ADDRESS, SOLANA)).willReturn(false);
-        given(addressFilter.mightContain(PROBE_ADDRESS, BITCOIN)).willReturn(false);
+        for (var networkType : NetworkType.values()) {
+            given(addressFilter.mightContain(PROBE_ADDRESS, networkType)).willReturn(false);
+        }
 
         registerBloomSizeGauge(EVM.name(), 150);
         registerBloomSizeGauge(SOLANA.name(), 50);
         registerBloomSizeGauge(BITCOIN.name(), 0);
 
+        var expectedFilters = new LinkedHashMap<String, Map<String, Object>>();
+        expectedFilters.put("EVM", filterDetail(true, 150L));
+        expectedFilters.put("SOLANA", filterDetail(true, 50L));
+        expectedFilters.put("BITCOIN", filterDetail(true, 0L));
+        expectedFilters.put("TRON", filterDetail(true, 0L));
+        expectedFilters.put("APTOS", filterDetail(true, 0L));
+        expectedFilters.put("SUI", filterDetail(true, 0L));
+        expectedFilters.put("COSMOS", filterDetail(true, 0L));
+        expectedFilters.put("TON", filterDetail(true, 0L));
+
         var expected = Health.up()
-                .withDetail("filters", buildExpectedFilters(
-                        filterDetail(true, 150L),
-                        filterDetail(true, 50L),
-                        filterDetail(true, 0L)))
+                .withDetail("filters", expectedFilters)
                 .build();
 
         // when
@@ -74,15 +83,23 @@ class BloomFilterHealthIndicatorTest {
         given(addressFilter.mightContain(PROBE_ADDRESS, SOLANA))
                 .willThrow(new RuntimeException("Redis connection refused"));
         given(addressFilter.mightContain(PROBE_ADDRESS, BITCOIN)).willReturn(false);
+        stubRemainingNetworkTypesAsAvailable(EVM, SOLANA, BITCOIN);
 
         registerBloomSizeGauge(EVM.name(), 100);
         registerBloomSizeGauge(BITCOIN.name(), 0);
 
+        var expectedFilters = new LinkedHashMap<String, Map<String, Object>>();
+        expectedFilters.put("EVM", filterDetail(true, 100L));
+        expectedFilters.put("SOLANA", filterDetail(false, 0L));
+        expectedFilters.put("BITCOIN", filterDetail(true, 0L));
+        expectedFilters.put("TRON", filterDetail(true, 0L));
+        expectedFilters.put("APTOS", filterDetail(true, 0L));
+        expectedFilters.put("SUI", filterDetail(true, 0L));
+        expectedFilters.put("COSMOS", filterDetail(true, 0L));
+        expectedFilters.put("TON", filterDetail(true, 0L));
+
         var expected = Health.down()
-                .withDetail("filters", buildExpectedFilters(
-                        filterDetail(true, 100L),
-                        filterDetail(false, 0L),
-                        filterDetail(true, 0L)))
+                .withDetail("filters", expectedFilters)
                 .build();
 
         // when
@@ -96,15 +113,17 @@ class BloomFilterHealthIndicatorTest {
     @DisplayName("reports entry count as zero when gauge is not registered")
     void reportsZeroEntryCountWhenNoGauge() {
         // given
-        given(addressFilter.mightContain(PROBE_ADDRESS, EVM)).willReturn(false);
-        given(addressFilter.mightContain(PROBE_ADDRESS, SOLANA)).willReturn(false);
-        given(addressFilter.mightContain(PROBE_ADDRESS, BITCOIN)).willReturn(false);
+        for (var networkType : NetworkType.values()) {
+            given(addressFilter.mightContain(PROBE_ADDRESS, networkType)).willReturn(false);
+        }
+
+        var expectedFilters = new LinkedHashMap<String, Map<String, Object>>();
+        for (var networkType : NetworkType.values()) {
+            expectedFilters.put(networkType.name(), filterDetail(true, 0L));
+        }
 
         var expected = Health.up()
-                .withDetail("filters", buildExpectedFilters(
-                        filterDetail(true, 0L),
-                        filterDetail(true, 0L),
-                        filterDetail(true, 0L)))
+                .withDetail("filters", expectedFilters)
                 .build();
 
         // when
@@ -118,18 +137,18 @@ class BloomFilterHealthIndicatorTest {
     @DisplayName("reports DOWN when all bloom filters are unavailable")
     void reportsDownWhenAllFiltersUnavailable() {
         // given
-        given(addressFilter.mightContain(PROBE_ADDRESS, EVM))
-                .willThrow(new RuntimeException("Redis down"));
-        given(addressFilter.mightContain(PROBE_ADDRESS, SOLANA))
-                .willThrow(new RuntimeException("Redis down"));
-        given(addressFilter.mightContain(PROBE_ADDRESS, BITCOIN))
-                .willThrow(new RuntimeException("Redis down"));
+        for (var networkType : NetworkType.values()) {
+            given(addressFilter.mightContain(PROBE_ADDRESS, networkType))
+                    .willThrow(new RuntimeException("Redis down"));
+        }
+
+        var expectedFilters = new LinkedHashMap<String, Map<String, Object>>();
+        for (var networkType : NetworkType.values()) {
+            expectedFilters.put(networkType.name(), filterDetail(false, 0L));
+        }
 
         var expected = Health.down()
-                .withDetail("filters", buildExpectedFilters(
-                        filterDetail(false, 0L),
-                        filterDetail(false, 0L),
-                        filterDetail(false, 0L)))
+                .withDetail("filters", expectedFilters)
                 .build();
 
         // when
@@ -146,15 +165,13 @@ class BloomFilterHealthIndicatorTest {
                 .register(meterRegistry);
     }
 
-    private static Map<String, Map<String, Object>> buildExpectedFilters(
-            Map<String, Object> evmDetail,
-            Map<String, Object> solanaDetail,
-            Map<String, Object> bitcoinDetail) {
-        var filters = new LinkedHashMap<String, Map<String, Object>>();
-        filters.put("EVM", evmDetail);
-        filters.put("SOLANA", solanaDetail);
-        filters.put("BITCOIN", bitcoinDetail);
-        return filters;
+    private void stubRemainingNetworkTypesAsAvailable(NetworkType... alreadyStubbed) {
+        var stubbedSet = Set.of(alreadyStubbed);
+        for (var networkType : NetworkType.values()) {
+            if (!stubbedSet.contains(networkType)) {
+                given(addressFilter.mightContain(PROBE_ADDRESS, networkType)).willReturn(false);
+            }
+        }
     }
 
     private static Map<String, Object> filterDetail(boolean available, long approximateEntryCount) {

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/domain/model/ChainIdTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/domain/model/ChainIdTest.java
@@ -1,0 +1,77 @@
+package com.stablebridge.indexer.domain.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ChainId")
+class ChainIdTest {
+
+    @ParameterizedTest
+    @EnumSource(ChainId.class)
+    @DisplayName("all chain IDs have a non-null network type")
+    void allChainIdsHaveNonNullNetworkType(ChainId chainId) {
+        // given — the enum constant
+
+        // when
+        var networkType = chainId.networkType();
+
+        // then
+        assertThat(networkType).isNotNull();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "ETHEREUM, EVM",
+            "POLYGON, EVM",
+            "ARBITRUM, EVM",
+            "OPTIMISM, EVM",
+            "BASE, EVM",
+            "AVALANCHE, EVM",
+            "BSC, EVM",
+            "SEPOLIA, EVM",
+            "BASE_SEPOLIA, EVM",
+            "SOLANA_CHAIN, SOLANA",
+            "SOLANA_DEVNET, SOLANA",
+            "BITCOIN_CHAIN, BITCOIN",
+            "BITCOIN_TESTNET, BITCOIN",
+            "TRON_CHAIN, TRON",
+            "TRON_SHASTA, TRON",
+            "APTOS_CHAIN, APTOS",
+            "APTOS_DEVNET, APTOS",
+            "SUI_CHAIN, SUI",
+            "SUI_DEVNET, SUI",
+            "NOBLE, COSMOS",
+            "OSMOSIS, COSMOS",
+            "COSMOS_HUB, COSMOS",
+            "TON_CHAIN, TON",
+            "TON_TESTNET, TON"
+    })
+    @DisplayName("maps chain ID to correct network type")
+    void mapsChainIdToCorrectNetworkType(ChainId chainId, NetworkType expectedNetworkType) {
+        // given — the enum constant and expected network type
+
+        // when
+        var actualNetworkType = chainId.networkType();
+
+        // then
+        assertThat(actualNetworkType).isEqualTo(expectedNetworkType);
+    }
+
+    @Test
+    @DisplayName("total chain ID count matches expected value")
+    void totalChainIdCountMatchesExpected() {
+        // given
+        var expectedCount = 24;
+
+        // when
+        var actualCount = ChainId.values().length;
+
+        // then
+        assertThat(actualCount).isEqualTo(expectedCount);
+    }
+}

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/bloom/RedisBloomAddressFilterTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/bloom/RedisBloomAddressFilterTest.java
@@ -222,22 +222,11 @@ class RedisBloomAddressFilterTest {
             filter.initializeFilters();
 
             // then
-            then(redisTemplate).should().execute(BF_RESERVE_SCRIPT, List.of("indexer:bloom:EVM"),
-                    String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS));
-            then(redisTemplate).should().execute(BF_RESERVE_SCRIPT, List.of("indexer:bloom:SOLANA"),
-                    String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS));
-            then(redisTemplate).should().execute(BF_RESERVE_SCRIPT, List.of("indexer:bloom:BITCOIN"),
-                    String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS));
-            then(redisTemplate).should().execute(BF_RESERVE_SCRIPT, List.of("indexer:bloom:TRON"),
-                    String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS));
-            then(redisTemplate).should().execute(BF_RESERVE_SCRIPT, List.of("indexer:bloom:APTOS"),
-                    String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS));
-            then(redisTemplate).should().execute(BF_RESERVE_SCRIPT, List.of("indexer:bloom:SUI"),
-                    String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS));
-            then(redisTemplate).should().execute(BF_RESERVE_SCRIPT, List.of("indexer:bloom:COSMOS"),
-                    String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS));
-            then(redisTemplate).should().execute(BF_RESERVE_SCRIPT, List.of("indexer:bloom:TON"),
-                    String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS));
+            for (var networkType : NetworkType.values()) {
+                then(redisTemplate).should().execute(BF_RESERVE_SCRIPT,
+                        List.of("indexer:bloom:" + networkType.name()),
+                        String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS));
+            }
         }
 
         @Test

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/bloom/RedisBloomAddressFilterTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/bloom/RedisBloomAddressFilterTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -226,21 +228,28 @@ class RedisBloomAddressFilterTest {
                     String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS));
             then(redisTemplate).should().execute(BF_RESERVE_SCRIPT, List.of("indexer:bloom:BITCOIN"),
                     String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS));
+            then(redisTemplate).should().execute(BF_RESERVE_SCRIPT, List.of("indexer:bloom:TRON"),
+                    String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS));
+            then(redisTemplate).should().execute(BF_RESERVE_SCRIPT, List.of("indexer:bloom:APTOS"),
+                    String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS));
+            then(redisTemplate).should().execute(BF_RESERVE_SCRIPT, List.of("indexer:bloom:SUI"),
+                    String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS));
+            then(redisTemplate).should().execute(BF_RESERVE_SCRIPT, List.of("indexer:bloom:COSMOS"),
+                    String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS));
+            then(redisTemplate).should().execute(BF_RESERVE_SCRIPT, List.of("indexer:bloom:TON"),
+                    String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS));
         }
 
         @Test
         @DisplayName("handles existing bloom filter gracefully without throwing")
         void handlesExistingFilterGracefully() {
             // given
-            given(redisTemplate.execute(BF_RESERVE_SCRIPT, List.of("indexer:bloom:EVM"),
-                    String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS)))
-                    .willThrow(new RuntimeException("ERR item exists"));
-            given(redisTemplate.execute(BF_RESERVE_SCRIPT, List.of("indexer:bloom:SOLANA"),
-                    String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS)))
-                    .willThrow(new RuntimeException("ERR item exists"));
-            given(redisTemplate.execute(BF_RESERVE_SCRIPT, List.of("indexer:bloom:BITCOIN"),
-                    String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS)))
-                    .willThrow(new RuntimeException("ERR item exists"));
+            for (var networkType : NetworkType.values()) {
+                given(redisTemplate.execute(BF_RESERVE_SCRIPT,
+                        List.of("indexer:bloom:" + networkType.name()),
+                        String.valueOf(ERROR_RATE), String.valueOf(EXPECTED_INSERTIONS)))
+                        .willThrow(new RuntimeException("ERR item exists"));
+            }
 
             // when / then — no exception propagates
             assertThatCode(() -> filter.initializeFilters()).doesNotThrowAnyException();
@@ -259,6 +268,60 @@ class RedisBloomAddressFilterTest {
                         .gauge();
                 assertThat(gauge).isNotNull();
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("address normalization")
+    class AddressNormalization {
+
+        private static final String MIXED_CASE_ADDRESS = "TAbCdEf1234567890xYz";
+        private static final String MIXED_CASE_ADDRESS_LOWER = MIXED_CASE_ADDRESS.toLowerCase();
+
+        @ParameterizedTest
+        @EnumSource(value = NetworkType.class, names = {"TRON", "APTOS", "SUI", "COSMOS", "TON"})
+        @DisplayName("lowercases address for case-insensitive network types")
+        void lowercasesAddressForCaseInsensitiveNetworkTypes(NetworkType networkType) {
+            // given
+            var bloomKey = "indexer:bloom:" + networkType.name();
+
+            // when
+            filter.add(MIXED_CASE_ADDRESS, networkType);
+
+            // then
+            then(redisTemplate).should()
+                    .execute(BF_ADD_SCRIPT, List.of(bloomKey), MIXED_CASE_ADDRESS_LOWER);
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = NetworkType.class, names = {"TRON", "APTOS", "SUI", "COSMOS", "TON"})
+        @DisplayName("lowercases address when checking bloom filter for case-insensitive network types")
+        void lowercasesAddressWhenCheckingBloomFilter(NetworkType networkType) {
+            // given
+            var bloomKey = "indexer:bloom:" + networkType.name();
+            given(redisTemplate.execute(BF_EXISTS_SCRIPT, List.of(bloomKey), MIXED_CASE_ADDRESS_LOWER))
+                    .willReturn(1L);
+
+            // when
+            var result = filter.mightContain(MIXED_CASE_ADDRESS, networkType);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = NetworkType.class, names = {"SOLANA", "BITCOIN"})
+        @DisplayName("preserves address case for case-sensitive network types")
+        void preservesAddressCaseForCaseSensitiveNetworkTypes(NetworkType networkType) {
+            // given
+            var bloomKey = "indexer:bloom:" + networkType.name();
+
+            // when
+            filter.add(MIXED_CASE_ADDRESS, networkType);
+
+            // then
+            then(redisTemplate).should()
+                    .execute(BF_ADD_SCRIPT, List.of(bloomKey), MIXED_CASE_ADDRESS);
         }
     }
 }


### PR DESCRIPTION
## SBI Issue
Closes #104

## Changes
- Add 5 new `NetworkType` enum values (TRON, APTOS, SUI, COSMOS, TON) to both API and domain modules
- Add 11 new `ChainId` entries: TRON_CHAIN, TRON_SHASTA, APTOS_CHAIN, APTOS_DEVNET, SUI_CHAIN, SUI_DEVNET, NOBLE, OSMOSIS, COSMOS_HUB, TON_CHAIN, TON_TESTNET
- Update `RedisBloomAddressFilter.normalizeAddress()` to lowercase addresses for all new network types (switch expression)
- Update `GuavaBloomAddressFilter.normalizeAddress()` with same switch expression
- Update `BloomFilterHealthIndicatorTest` to handle 8 network types

## Test plan
- [x] New `ChainIdTest` — parameterized tests verifying all 24 ChainId→NetworkType mappings
- [x] New normalization tests in `RedisBloomAddressFilterTest` — verifies lowercasing for TRON/APTOS/SUI/COSMOS/TON and case preservation for SOLANA/BITCOIN
- [x] Updated `initializeFilters` test covers all 8 network types
- [x] Updated `BloomFilterHealthIndicatorTest` covers all 8 network types
- [x] `./gradlew build` passes (compile + Spotless + all tests)
- [x] ArchUnit rules pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)