### PR TITLE
SBI-54: add TRON native TRX transfer parser

### DIFF
--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/tron/TronAddressConverter.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/tron/TronAddressConverter.java
@@ -56,6 +56,9 @@ class TronAddressConverter {
         }
 
         var payload = hexToBytes(normalized);
+        if (payload[0] != TRON_PREFIX) {
+            throw new IllegalArgumentException("TRON address must start with 0x41 prefix");
+        }
         var checksum = computeChecksum(payload);
         var full = new byte[FULL_DECODED_LENGTH];
         System.arraycopy(payload, 0, full, 0, ADDRESS_BYTES_WITH_PREFIX);
@@ -178,11 +181,6 @@ class TronAddressConverter {
                 throw new IllegalArgumentException("invalid hex character at position " + (i * 2));
             }
             out[i] = (byte) ((hi << 4) | lo);
-        }
-        // Validate TRON prefix on 21-byte payloads (defensive)
-        if (out.length == ADDRESS_BYTES_WITH_PREFIX && out[0] != TRON_PREFIX) {
-            throw new IllegalArgumentException(
-                    "TRON address must start with 0x41 prefix");
         }
         return out;
     }

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/tron/TronAddressConverter.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/tron/TronAddressConverter.java
@@ -1,0 +1,193 @@
+package com.stablebridge.indexer.infrastructure.chain.tron;
+
+import lombok.experimental.UtilityClass;
+
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+@UtilityClass
+class TronAddressConverter {
+
+    private static final String BASE58_ALPHABET =
+            "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    private static final BigInteger BASE = BigInteger.valueOf(58);
+    private static final int ADDRESS_BYTES_WITH_PREFIX = 21;
+    private static final int CHECKSUM_LENGTH = 4;
+    private static final int FULL_DECODED_LENGTH = ADDRESS_BYTES_WITH_PREFIX + CHECKSUM_LENGTH;
+    private static final byte TRON_PREFIX = (byte) 0x41;
+    private static final String TRON_PREFIX_HEX = "41";
+    private static final int TOPIC_ADDRESS_HEX_LENGTH = 40;
+
+    static String base58ToHex(String base58Address) {
+        if (base58Address == null) {
+            throw new IllegalArgumentException("base58 address must not be null");
+        }
+
+        var decoded = decodeBase58(base58Address);
+        if (decoded.length != FULL_DECODED_LENGTH) {
+            throw new IllegalArgumentException(
+                    "decoded TRON address must be " + FULL_DECODED_LENGTH
+                            + " bytes, got " + decoded.length);
+        }
+
+        var payload = Arrays.copyOfRange(decoded, 0, ADDRESS_BYTES_WITH_PREFIX);
+        var providedChecksum = Arrays.copyOfRange(decoded, ADDRESS_BYTES_WITH_PREFIX, FULL_DECODED_LENGTH);
+        var expectedChecksum = computeChecksum(payload);
+
+        if (!Arrays.equals(providedChecksum, expectedChecksum)) {
+            throw new IllegalArgumentException("TRON address checksum mismatch for " + base58Address);
+        }
+
+        return bytesToHex(payload);
+    }
+
+    static String hexToBase58(String hexAddress) {
+        if (hexAddress == null) {
+            throw new IllegalArgumentException("hex address must not be null");
+        }
+
+        var normalized = stripHexPrefix(hexAddress).toLowerCase();
+        if (normalized.length() != ADDRESS_BYTES_WITH_PREFIX * 2) {
+            throw new IllegalArgumentException(
+                    "hex TRON address must be " + (ADDRESS_BYTES_WITH_PREFIX * 2)
+                            + " chars, got " + normalized.length());
+        }
+
+        var payload = hexToBytes(normalized);
+        var checksum = computeChecksum(payload);
+        var full = new byte[FULL_DECODED_LENGTH];
+        System.arraycopy(payload, 0, full, 0, ADDRESS_BYTES_WITH_PREFIX);
+        System.arraycopy(checksum, 0, full, ADDRESS_BYTES_WITH_PREFIX, CHECKSUM_LENGTH);
+
+        return encodeBase58(full);
+    }
+
+    static String topicToHex(String topic) {
+        if (topic == null) {
+            throw new IllegalArgumentException("topic must not be null");
+        }
+
+        var normalized = stripHexPrefix(topic).toLowerCase();
+        if (normalized.length() < TOPIC_ADDRESS_HEX_LENGTH) {
+            throw new IllegalArgumentException(
+                    "topic must be at least " + TOPIC_ADDRESS_HEX_LENGTH + " hex chars");
+        }
+
+        var suffix = normalized.substring(normalized.length() - TOPIC_ADDRESS_HEX_LENGTH);
+        return TRON_PREFIX_HEX + suffix;
+    }
+
+    static String logAddressToHex(String logAddress) {
+        if (logAddress == null) {
+            throw new IllegalArgumentException("log address must not be null");
+        }
+
+        var normalized = stripHexPrefix(logAddress).toLowerCase();
+        if (normalized.length() != TOPIC_ADDRESS_HEX_LENGTH) {
+            throw new IllegalArgumentException(
+                    "log address must be " + TOPIC_ADDRESS_HEX_LENGTH
+                            + " hex chars, got " + normalized.length());
+        }
+
+        return TRON_PREFIX_HEX + normalized;
+    }
+
+    private static byte[] decodeBase58(String input) {
+        if (input.isEmpty()) {
+            throw new IllegalArgumentException("base58 input must not be empty");
+        }
+
+        var value = BigInteger.ZERO;
+        for (var i = 0; i < input.length(); i++) {
+            var c = input.charAt(i);
+            var digit = BASE58_ALPHABET.indexOf(c);
+            if (digit < 0) {
+                throw new IllegalArgumentException(
+                        "invalid Base58 character '" + c + "' at position " + i);
+            }
+            value = value.multiply(BASE).add(BigInteger.valueOf(digit));
+        }
+
+        var payload = value.toByteArray();
+        if (payload.length > 0 && payload[0] == 0) {
+            payload = Arrays.copyOfRange(payload, 1, payload.length);
+        }
+
+        var leadingZeros = 0;
+        while (leadingZeros < input.length() && input.charAt(leadingZeros) == BASE58_ALPHABET.charAt(0)) {
+            leadingZeros++;
+        }
+
+        var decoded = new byte[leadingZeros + payload.length];
+        System.arraycopy(payload, 0, decoded, leadingZeros, payload.length);
+        return decoded;
+    }
+
+    private static String encodeBase58(byte[] input) {
+        var leadingZeros = 0;
+        while (leadingZeros < input.length && input[leadingZeros] == 0) {
+            leadingZeros++;
+        }
+
+        var value = new BigInteger(1, input);
+        var sb = new StringBuilder();
+        while (value.signum() > 0) {
+            var divmod = value.divideAndRemainder(BASE);
+            value = divmod[0];
+            sb.append(BASE58_ALPHABET.charAt(divmod[1].intValue()));
+        }
+        for (var i = 0; i < leadingZeros; i++) {
+            sb.append(BASE58_ALPHABET.charAt(0));
+        }
+        return sb.reverse().toString();
+    }
+
+    private static byte[] computeChecksum(byte[] payload) {
+        var hashed = sha256(sha256(payload));
+        return Arrays.copyOfRange(hashed, 0, CHECKSUM_LENGTH);
+    }
+
+    private static byte[] sha256(byte[] input) {
+        try {
+            var digest = MessageDigest.getInstance("SHA-256");
+            return digest.digest(input);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm not available", e);
+        }
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        var sb = new StringBuilder(bytes.length * 2);
+        for (var b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    private static byte[] hexToBytes(String hex) {
+        if ((hex.length() & 1) != 0) {
+            throw new IllegalArgumentException("hex string must have even length");
+        }
+        var out = new byte[hex.length() / 2];
+        for (var i = 0; i < out.length; i++) {
+            var hi = Character.digit(hex.charAt(i * 2), 16);
+            var lo = Character.digit(hex.charAt(i * 2 + 1), 16);
+            if (hi < 0 || lo < 0) {
+                throw new IllegalArgumentException("invalid hex character at position " + (i * 2));
+            }
+            out[i] = (byte) ((hi << 4) | lo);
+        }
+        // Validate TRON prefix on 21-byte payloads (defensive)
+        if (out.length == ADDRESS_BYTES_WITH_PREFIX && out[0] != TRON_PREFIX) {
+            throw new IllegalArgumentException(
+                    "TRON address must start with 0x41 prefix");
+        }
+        return out;
+    }
+
+    private static String stripHexPrefix(String hex) {
+        return hex.startsWith("0x") || hex.startsWith("0X") ? hex.substring(2) : hex;
+    }
+}

--- a/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/tron/TronNativeTransferParser.java
+++ b/stablebridge-indexer/src/main/java/com/stablebridge/indexer/infrastructure/chain/tron/TronNativeTransferParser.java
@@ -1,0 +1,74 @@
+package com.stablebridge.indexer.infrastructure.chain.tron;
+
+import com.stablebridge.indexer.domain.model.ChainId;
+import com.stablebridge.indexer.domain.model.Transfer;
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Slf4j
+class TronNativeTransferParser {
+
+    private static final String NATIVE_SYMBOL = "TRX";
+    private static final int TRX_DECIMALS = 6;
+    private static final int NATIVE_TRANSFER_LOG_INDEX = -1;
+    private static final BigDecimal SUN_PER_TRX = BigDecimal.TEN.pow(TRX_DECIMALS);
+
+    private final ChainId chainId;
+
+    TronNativeTransferParser(ChainId chainId) {
+        this.chainId = chainId;
+    }
+
+    List<Transfer> parseNativeTransfers(TronBlock block) {
+        if (block.transactions() == null || block.transactions().isEmpty()) {
+            return List.of();
+        }
+
+        var txs = block.transactions();
+        var blockNumber = block.blockNumber();
+        var blockHash = block.blockID();
+        var blockTimestamp = block.blockTimestamp();
+
+        return IntStream.range(0, txs.size())
+                .filter(i -> txs.get(i).isNativeTransfer())
+                .filter(i -> txs.get(i).ownerAddress() != null)
+                .filter(i -> txs.get(i).toAddress() != null)
+                .filter(i -> txs.get(i).amount() != 0)
+                .mapToObj(i -> buildTransfer(txs.get(i), i, blockNumber, blockHash, blockTimestamp))
+                .toList();
+    }
+
+    private Transfer buildTransfer(
+            TronTransaction tx,
+            int txIndex,
+            long blockNumber,
+            String blockHash,
+            Instant blockTimestamp) {
+        var amountSun = tx.amount();
+        var rawAmount = String.valueOf(amountSun);
+        var amount = BigDecimal.valueOf(amountSun).divide(SUN_PER_TRX, TRX_DECIMALS, RoundingMode.HALF_UP);
+
+        return Transfer.builder()
+                .txHash(tx.txID())
+                .fromAddress(TronAddressConverter.base58ToHex(tx.ownerAddress()))
+                .toAddress(TronAddressConverter.base58ToHex(tx.toAddress()))
+                .rawAmount(rawAmount)
+                .amount(amount)
+                .decimals(TRX_DECIMALS)
+                .tokenSymbol(NATIVE_SYMBOL)
+                .tokenContractAddress(null)
+                .blockNumber(blockNumber)
+                .blockHash(blockHash)
+                .transactionIndex(txIndex)
+                .logIndex(NATIVE_TRANSFER_LOG_INDEX)
+                .chainId(chainId)
+                .timestamp(blockTimestamp)
+                .nativeTransfer(true)
+                .build();
+    }
+}

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/tron/TronAddressConverterTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/tron/TronAddressConverterTest.java
@@ -1,0 +1,240 @@
+package com.stablebridge.indexer.infrastructure.chain.tron;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("TronAddressConverter")
+class TronAddressConverterTest {
+
+    private static final String USDT_BASE58 = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+    private static final String USDT_HEX = "41a614f803b6fd780986a42c78ec9c7f77e6ded13c";
+
+    @Nested
+    @DisplayName("base58ToHex")
+    class Base58ToHex {
+
+        @Test
+        @DisplayName("converts known TRON address to lowercase hex with 41 prefix")
+        void convertsKnownTronAddress() {
+            // given
+            var base58 = USDT_BASE58;
+
+            // when
+            var result = TronAddressConverter.base58ToHex(base58);
+
+            // then
+            assertThat(result).isEqualTo(USDT_HEX);
+        }
+
+        @Test
+        @DisplayName("throws when input is null")
+        void throwsWhenNull() {
+            // given
+            String base58 = null;
+
+            // when / then
+            assertThatThrownBy(() -> TronAddressConverter.base58ToHex(base58))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("throws when input contains invalid Base58 character")
+        void throwsWhenInvalidCharacter() {
+            // given — '0' is not in the Base58 alphabet
+            var invalid = "TR0NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+
+            // when / then
+            assertThatThrownBy(() -> TronAddressConverter.base58ToHex(invalid))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("throws when checksum does not match")
+        void throwsWhenChecksumMismatch() {
+            // given — mutate the last character of a valid address to break the checksum
+            var tampered = USDT_BASE58.substring(0, USDT_BASE58.length() - 1) + "u";
+
+            // when / then
+            assertThatThrownBy(() -> TronAddressConverter.base58ToHex(tampered))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("hexToBase58")
+    class HexToBase58 {
+
+        @Test
+        @DisplayName("converts known hex to Base58Check")
+        void convertsKnownHex() {
+            // given
+            var hex = USDT_HEX;
+
+            // when
+            var result = TronAddressConverter.hexToBase58(hex);
+
+            // then
+            assertThat(result).isEqualTo(USDT_BASE58);
+        }
+
+        @Test
+        @DisplayName("accepts uppercase hex")
+        void acceptsUppercaseHex() {
+            // given
+            var hexUpper = USDT_HEX.toUpperCase();
+
+            // when
+            var result = TronAddressConverter.hexToBase58(hexUpper);
+
+            // then
+            assertThat(result).isEqualTo(USDT_BASE58);
+        }
+
+        @Test
+        @DisplayName("throws when input is null")
+        void throwsWhenNull() {
+            // given
+            String hex = null;
+
+            // when / then
+            assertThatThrownBy(() -> TronAddressConverter.hexToBase58(hex))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("throws when hex length is wrong")
+        void throwsWhenWrongLength() {
+            // given — too short
+            var shortHex = "41a614f803b6fd780986a42c78ec9c7f77e6ded1";
+
+            // when / then
+            assertThatThrownBy(() -> TronAddressConverter.hexToBase58(shortHex))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("roundtrip")
+    class Roundtrip {
+
+        @Test
+        @DisplayName("base58 -> hex -> base58 returns original")
+        void base58Roundtrip() {
+            // given
+            var base58 = USDT_BASE58;
+
+            // when
+            var hex = TronAddressConverter.base58ToHex(base58);
+            var result = TronAddressConverter.hexToBase58(hex);
+
+            // then
+            assertThat(result).isEqualTo(base58);
+        }
+
+        @Test
+        @DisplayName("hex -> base58 -> hex returns original")
+        void hexRoundtrip() {
+            // given
+            var hex = USDT_HEX;
+
+            // when
+            var base58 = TronAddressConverter.hexToBase58(hex);
+            var result = TronAddressConverter.base58ToHex(base58);
+
+            // then
+            assertThat(result).isEqualTo(hex);
+        }
+    }
+
+    @Nested
+    @DisplayName("topicToHex")
+    class TopicToHex {
+
+        @Test
+        @DisplayName("extracts last 40 hex chars and prepends 41")
+        void extractsAddressFromTopic() {
+            // given
+            var topic = "0x000000000000000000000041a614f803b6fd780986a42c78ec9c7f77e6ded13c";
+
+            // when
+            var result = TronAddressConverter.topicToHex(topic);
+
+            // then
+            assertThat(result).isEqualTo(USDT_HEX);
+        }
+
+        @Test
+        @DisplayName("handles topic without 0x prefix")
+        void handlesTopicWithoutPrefix() {
+            // given
+            var topic = "000000000000000000000041a614f803b6fd780986a42c78ec9c7f77e6ded13c";
+
+            // when
+            var result = TronAddressConverter.topicToHex(topic);
+
+            // then
+            assertThat(result).isEqualTo(USDT_HEX);
+        }
+
+        @Test
+        @DisplayName("returns lowercase hex")
+        void returnsLowercase() {
+            // given
+            var topic = "0x000000000000000000000041A614F803B6FD780986A42C78EC9C7F77E6DED13C";
+
+            // when
+            var result = TronAddressConverter.topicToHex(topic);
+
+            // then
+            assertThat(result).isEqualTo(USDT_HEX);
+        }
+    }
+
+    @Nested
+    @DisplayName("logAddressToHex")
+    class LogAddressToHex {
+
+        @Test
+        @DisplayName("prepends 41 to address without prefix")
+        void prependsPrefix() {
+            // given
+            var logAddress = "a614f803b6fd780986a42c78ec9c7f77e6ded13c";
+
+            // when
+            var result = TronAddressConverter.logAddressToHex(logAddress);
+
+            // then
+            assertThat(result).isEqualTo(USDT_HEX);
+        }
+
+        @Test
+        @DisplayName("handles 0x prefix and strips it before prepending 41")
+        void stripsHexPrefix() {
+            // given
+            var logAddress = "0xa614f803b6fd780986a42c78ec9c7f77e6ded13c";
+
+            // when
+            var result = TronAddressConverter.logAddressToHex(logAddress);
+
+            // then
+            assertThat(result).isEqualTo(USDT_HEX);
+        }
+
+        @Test
+        @DisplayName("returns lowercase hex")
+        void returnsLowercase() {
+            // given
+            var logAddress = "A614F803B6FD780986A42C78EC9C7F77E6DED13C";
+
+            // when
+            var result = TronAddressConverter.logAddressToHex(logAddress);
+
+            // then
+            assertThat(result).isEqualTo(USDT_HEX);
+        }
+    }
+}

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/tron/TronNativeTransferParserTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/tron/TronNativeTransferParserTest.java
@@ -90,13 +90,45 @@ class TronNativeTransferParserTest {
             var result = parser.parseNativeTransfers(block);
 
             // then
-            assertThat(result).hasSize(2);
-            assertThat(result.get(0).txHash()).isEqualTo("0xtx_1");
-            assertThat(result.get(0).rawAmount()).isEqualTo("1000000");
-            assertThat(result.get(0).transactionIndex()).isEqualTo(0);
-            assertThat(result.get(1).txHash()).isEqualTo("0xtx_2");
-            assertThat(result.get(1).rawAmount()).isEqualTo("2500000");
-            assertThat(result.get(1).transactionIndex()).isEqualTo(1);
+            var expected1 = Transfer.builder()
+                    .txHash("0xtx_1")
+                    .fromAddress(SOME_FROM_HEX)
+                    .toAddress(SOME_TO_HEX)
+                    .rawAmount("1000000")
+                    .amount(new BigDecimal("1.000000"))
+                    .decimals(TRX_DECIMALS)
+                    .tokenSymbol("TRX")
+                    .tokenContractAddress(null)
+                    .blockNumber(SOME_BLOCK_NUMBER)
+                    .blockHash(SOME_BLOCK_ID)
+                    .transactionIndex(0)
+                    .logIndex(-1)
+                    .chainId(TRON_CHAIN)
+                    .timestamp(SOME_BLOCK_TIMESTAMP)
+                    .nativeTransfer(true)
+                    .build();
+            var expected2 = Transfer.builder()
+                    .txHash("0xtx_2")
+                    .fromAddress(SOME_FROM_HEX)
+                    .toAddress(SOME_TO_HEX)
+                    .rawAmount("2500000")
+                    .amount(new BigDecimal("2.500000"))
+                    .decimals(TRX_DECIMALS)
+                    .tokenSymbol("TRX")
+                    .tokenContractAddress(null)
+                    .blockNumber(SOME_BLOCK_NUMBER)
+                    .blockHash(SOME_BLOCK_ID)
+                    .transactionIndex(1)
+                    .logIndex(-1)
+                    .chainId(TRON_CHAIN)
+                    .timestamp(SOME_BLOCK_TIMESTAMP)
+                    .nativeTransfer(true)
+                    .build();
+
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+                    .isEqualTo(List.of(expected1, expected2));
         }
 
         @Test

--- a/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/tron/TronNativeTransferParserTest.java
+++ b/stablebridge-indexer/src/test/java/com/stablebridge/indexer/infrastructure/chain/tron/TronNativeTransferParserTest.java
@@ -1,0 +1,265 @@
+package com.stablebridge.indexer.infrastructure.chain.tron;
+
+import com.stablebridge.indexer.domain.model.Transfer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static com.stablebridge.indexer.domain.model.ChainId.TRON_CHAIN;
+import static com.stablebridge.indexer.infrastructure.chain.tron.TronFixtures.SOME_AMOUNT_SUN;
+import static com.stablebridge.indexer.infrastructure.chain.tron.TronFixtures.SOME_BLOCK_ID;
+import static com.stablebridge.indexer.infrastructure.chain.tron.TronFixtures.SOME_BLOCK_NUMBER;
+import static com.stablebridge.indexer.infrastructure.chain.tron.TronFixtures.SOME_BLOCK_TIMESTAMP;
+import static com.stablebridge.indexer.infrastructure.chain.tron.TronFixtures.SOME_FROM_BASE58;
+import static com.stablebridge.indexer.infrastructure.chain.tron.TronFixtures.SOME_FROM_HEX;
+import static com.stablebridge.indexer.infrastructure.chain.tron.TronFixtures.SOME_TO_BASE58;
+import static com.stablebridge.indexer.infrastructure.chain.tron.TronFixtures.SOME_TO_HEX;
+import static com.stablebridge.indexer.infrastructure.chain.tron.TronFixtures.SOME_TX_HASH;
+import static com.stablebridge.indexer.infrastructure.chain.tron.TronFixtures.aNonTransferContractTransaction;
+import static com.stablebridge.indexer.infrastructure.chain.tron.TronFixtures.aTronBlock;
+import static com.stablebridge.indexer.infrastructure.chain.tron.TronFixtures.aTronTransaction;
+import static com.stablebridge.indexer.infrastructure.chain.tron.TronFixtures.aTronTransferContractTransaction;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("TronNativeTransferParser")
+class TronNativeTransferParserTest {
+
+    private static final int TRX_DECIMALS = 6;
+
+    private final TronNativeTransferParser parser = new TronNativeTransferParser(TRON_CHAIN);
+
+    @Nested
+    @DisplayName("parseNativeTransfers")
+    class ParseNativeTransfers {
+
+        @Test
+        @DisplayName("parses single native TRX transfer with correct amount conversion")
+        void parsesSingleNativeTransfer() {
+            // given
+            var block = aTronBlock()
+                    .transactions(List.of(aTronTransferContractTransaction().build()))
+                    .build();
+
+            // when
+            var result = parser.parseNativeTransfers(block);
+
+            // then
+            var expected = Transfer.builder()
+                    .txHash(SOME_TX_HASH)
+                    .fromAddress(SOME_FROM_HEX)
+                    .toAddress(SOME_TO_HEX)
+                    .rawAmount(String.valueOf(SOME_AMOUNT_SUN))
+                    .amount(new BigDecimal("1.000000"))
+                    .decimals(TRX_DECIMALS)
+                    .tokenSymbol("TRX")
+                    .tokenContractAddress(null)
+                    .blockNumber(SOME_BLOCK_NUMBER)
+                    .blockHash(SOME_BLOCK_ID)
+                    .transactionIndex(0)
+                    .logIndex(-1)
+                    .chainId(TRON_CHAIN)
+                    .timestamp(SOME_BLOCK_TIMESTAMP)
+                    .nativeTransfer(true)
+                    .build();
+
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst())
+                    .usingRecursiveComparison()
+                    .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("parses multiple native transfers from a single block")
+        void parsesMultipleNativeTransfers() {
+            // given
+            var tx1 = aTronTransaction(SOME_FROM_BASE58, SOME_TO_BASE58, 1_000_000L)
+                    .txID("0xtx_1")
+                    .build();
+            var tx2 = aTronTransaction(SOME_FROM_BASE58, SOME_TO_BASE58, 2_500_000L)
+                    .txID("0xtx_2")
+                    .build();
+            var block = aTronBlock()
+                    .transactions(List.of(tx1, tx2))
+                    .build();
+
+            // when
+            var result = parser.parseNativeTransfers(block);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).txHash()).isEqualTo("0xtx_1");
+            assertThat(result.get(0).rawAmount()).isEqualTo("1000000");
+            assertThat(result.get(0).transactionIndex()).isEqualTo(0);
+            assertThat(result.get(1).txHash()).isEqualTo("0xtx_2");
+            assertThat(result.get(1).rawAmount()).isEqualTo("2500000");
+            assertThat(result.get(1).transactionIndex()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("skips non-TransferContract transactions")
+        void skipsNonTransferContractTransactions() {
+            // given
+            var triggerSmartContract = aNonTransferContractTransaction()
+                    .txID("0xtx_trigger")
+                    .build();
+            var nativeTransfer = aTronTransferContractTransaction()
+                    .txID("0xtx_native")
+                    .build();
+            var block = aTronBlock()
+                    .transactions(List.of(triggerSmartContract, nativeTransfer))
+                    .build();
+
+            // when
+            var result = parser.parseNativeTransfers(block);
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst().txHash()).isEqualTo("0xtx_native");
+        }
+
+        @Test
+        @DisplayName("skips transactions with null owner address")
+        void skipsTransactionsWithNullOwnerAddress() {
+            // given
+            var tx = aTronTransaction(null, SOME_TO_BASE58, SOME_AMOUNT_SUN).build();
+            var block = aTronBlock()
+                    .transactions(List.of(tx))
+                    .build();
+
+            // when
+            var result = parser.parseNativeTransfers(block);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("skips transactions with null to address")
+        void skipsTransactionsWithNullToAddress() {
+            // given
+            var tx = aTronTransaction(SOME_FROM_BASE58, null, SOME_AMOUNT_SUN).build();
+            var block = aTronBlock()
+                    .transactions(List.of(tx))
+                    .build();
+
+            // when
+            var result = parser.parseNativeTransfers(block);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("skips transactions with zero amount")
+        void skipsZeroAmountTransactions() {
+            // given
+            var zeroTx = aTronTransaction(SOME_FROM_BASE58, SOME_TO_BASE58, 0L)
+                    .txID("0xtx_zero")
+                    .build();
+            var nonZeroTx = aTronTransferContractTransaction()
+                    .txID("0xtx_nonzero")
+                    .build();
+            var block = aTronBlock()
+                    .transactions(List.of(zeroTx, nonZeroTx))
+                    .build();
+
+            // when
+            var result = parser.parseNativeTransfers(block);
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst().txHash()).isEqualTo("0xtx_nonzero");
+        }
+
+        @Test
+        @DisplayName("returns empty list for empty transactions")
+        void returnsEmptyForEmptyTransactions() {
+            // given
+            var block = aTronBlock()
+                    .transactions(List.of())
+                    .build();
+
+            // when
+            var result = parser.parseNativeTransfers(block);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("returns empty list for null transactions")
+        void returnsEmptyForNullTransactions() {
+            // given
+            var block = aTronBlock()
+                    .transactions(null)
+                    .build();
+
+            // when
+            var result = parser.parseNativeTransfers(block);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("transfer properties")
+    class TransferProperties {
+
+        @Test
+        @DisplayName("sets nativeTransfer flag to true")
+        void setsNativeTransferFlag() {
+            // given
+            var block = aTronBlock().build();
+
+            // when
+            var result = parser.parseNativeTransfers(block);
+
+            // then
+            assertThat(result.getFirst().nativeTransfer()).isTrue();
+        }
+
+        @Test
+        @DisplayName("sets tokenContractAddress to null for native transfers")
+        void setsTokenContractAddressToNull() {
+            // given
+            var block = aTronBlock().build();
+
+            // when
+            var result = parser.parseNativeTransfers(block);
+
+            // then
+            assertThat(result.getFirst().tokenContractAddress()).isNull();
+        }
+
+        @Test
+        @DisplayName("sets logIndex to -1 for native transfers")
+        void setsLogIndexToNegativeOne() {
+            // given
+            var block = aTronBlock().build();
+
+            // when
+            var result = parser.parseNativeTransfers(block);
+
+            // then
+            assertThat(result.getFirst().logIndex()).isEqualTo(-1);
+        }
+
+        @Test
+        @DisplayName("sets chainId from constructor")
+        void setsChainIdFromConstructor() {
+            // given
+            var block = aTronBlock().build();
+
+            // when
+            var result = parser.parseNativeTransfers(block);
+
+            // then
+            assertThat(result.getFirst().chainId()).isEqualTo(TRON_CHAIN);
+        }
+    }
+}

--- a/stablebridge-indexer/src/testFixtures/java/com/stablebridge/indexer/infrastructure/chain/tron/TronFixtures.java
+++ b/stablebridge-indexer/src/testFixtures/java/com/stablebridge/indexer/infrastructure/chain/tron/TronFixtures.java
@@ -1,0 +1,92 @@
+package com.stablebridge.indexer.infrastructure.chain.tron;
+
+import java.time.Instant;
+import java.util.List;
+
+public final class TronFixtures {
+
+    public static final String SOME_FROM_BASE58 = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+    public static final String SOME_FROM_HEX = "41a614f803b6fd780986a42c78ec9c7f77e6ded13c";
+    public static final String SOME_TO_BASE58 = "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7";
+    public static final String SOME_TO_HEX = "4174472e7d35395a6b5add427eecb7f4b62ad2b071";
+    public static final String SOME_TX_HASH =
+            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+    public static final String SOME_BLOCK_ID =
+            "0000000003b0b2b71234567890abcdef1234567890abcdef1234567890abcdef";
+    public static final long SOME_BLOCK_NUMBER = 62_000_823L;
+    public static final long SOME_BLOCK_TIMESTAMP_MILLIS = 1_700_000_000_000L;
+    public static final Instant SOME_BLOCK_TIMESTAMP =
+            Instant.ofEpochMilli(SOME_BLOCK_TIMESTAMP_MILLIS);
+    public static final long SOME_AMOUNT_SUN = 1_000_000L; // 1 TRX
+    public static final String SOME_PARENT_HASH =
+            "0000000003b0b2b61234567890abcdef1234567890abcdef1234567890abcdef";
+
+    private TronFixtures() {
+        // fixture class
+    }
+
+    public static TronBlock.TronBlockBuilder aTronBlock() {
+        return TronBlock.builder()
+                .blockID(SOME_BLOCK_ID)
+                .block_header(aBlockHeader().build())
+                .transactions(List.of(aTronTransferContractTransaction().build()));
+    }
+
+    public static TronBlock.BlockHeader.BlockHeaderBuilder aBlockHeader() {
+        return TronBlock.BlockHeader.builder()
+                .raw_data(aRawBlockData().build());
+    }
+
+    public static TronBlock.RawData.RawDataBuilder aRawBlockData() {
+        return TronBlock.RawData.builder()
+                .number(SOME_BLOCK_NUMBER)
+                .timestamp(SOME_BLOCK_TIMESTAMP_MILLIS)
+                .parentHash(SOME_PARENT_HASH);
+    }
+
+    public static TronTransaction.TronTransactionBuilder aTronTransferContractTransaction() {
+        return aTronTransaction(SOME_FROM_BASE58, SOME_TO_BASE58, SOME_AMOUNT_SUN);
+    }
+
+    public static TronTransaction.TronTransactionBuilder aTronTransaction(
+            String ownerAddress, String toAddress, Long amountSun) {
+        return aTronTransactionWithType("TransferContract", ownerAddress, toAddress, amountSun);
+    }
+
+    public static TronTransaction.TronTransactionBuilder aTronTransactionWithType(
+            String contractType, String ownerAddress, String toAddress, Long amountSun) {
+        var value = TronTransaction.ContractValue.builder()
+                .owner_address(ownerAddress)
+                .to_address(toAddress)
+                .amount(amountSun)
+                .build();
+
+        var parameter = TronTransaction.ContractParameter.builder()
+                .value(value)
+                .type_url("type.googleapis.com/protocol." + contractType)
+                .build();
+
+        var contract = TronTransaction.Contract.builder()
+                .type(contractType)
+                .parameter(parameter)
+                .build();
+
+        var rawData = TronTransaction.RawData.builder()
+                .contract(List.of(contract))
+                .build();
+
+        var ret = TronTransaction.RetResult.builder()
+                .contractRet("SUCCESS")
+                .build();
+
+        return TronTransaction.builder()
+                .txID(SOME_TX_HASH)
+                .ret(List.of(ret))
+                .raw_data(rawData);
+    }
+
+    public static TronTransaction.TronTransactionBuilder aNonTransferContractTransaction() {
+        return aTronTransactionWithType(
+                "TriggerSmartContract", SOME_FROM_BASE58, SOME_TO_BASE58, SOME_AMOUNT_SUN);
+    }
+}


### PR DESCRIPTION
## SBI Issue
Closes #106

## Changes
- Add `TronAddressConverter` (`@UtilityClass`) with SHA-256 Base58Check codec — `base58ToHex`, `hexToBase58`, `topicToHex`, `logAddressToHex`. No external dependency.
- Add `TronNativeTransferParser` — detects `TransferContract` transactions, converts owner/to Base58Check addresses to lowercase hex with `41` prefix, scales SUN → TRX at 6 decimals, emits `Transfer` with `logIndex=-1`, `nativeTransfer=true`, `tokenSymbol="TRX"`.
- Defensive filtering: skip transactions with null owner/to or zero amount.
- Functional style via `IntStream.range` to derive `transactionIndex` without imperative loops.
- Add `TronFixtures` test fixture under `infrastructure/chain/tron` (needed to reach package-private `TronBlock` / `TronTransaction` builders).
- Unit tests: 16 for `TronAddressConverter` (roundtrip, topic, log address, error paths) and 12 for `TronNativeTransferParser` (single/multi transfer, skip branches, property checks) — single recursive-comparison assertions with `BigDecimal` comparator.

## Notes / Deviations
- Used `ChainId.TRON_CHAIN` (enum defines `TRON_CHAIN` / `TRON_SHASTA` from SBI-52; issue template said `TRON`).
- `TronFixtures` placed in `infrastructure/chain/tron` rather than `testutil/` so it can access package-private builders.

## Checklist
- [x] `./gradlew build` passes (compile + Spotless + unit + integration)
- [x] Unit tests added (28 new tests)
- [x] ArchUnit rules pass
- [x] Spotless formatting applied